### PR TITLE
fix(pos-web): remove dialog assertion after closing ticket

### DIFF
--- a/e2e/pos-web/src/features/create-tickets.feature
+++ b/e2e/pos-web/src/features/create-tickets.feature
@@ -208,8 +208,5 @@ Feature: Create tickets
 
     When I click on the "Percent Split" button in the split tip screen
     Then I should see all split tips non-zero
-
     When I click on the "Close Ticket" button
-    Then I should see a popup dialog with title "Close Ticket"
-    When I click on the "confirm" button in the popup dialog
     Then I should be redirected to HOME page


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Removes the check for the "Close Ticket" confirmation dialog in the create-tickets feature.