### PR TITLE
fix(pos-web): update button in new customer dialog and steps in appointment scenario

### DIFF
--- a/e2e/pos-web/src/const.ts
+++ b/e2e/pos-web/src/const.ts
@@ -75,7 +75,7 @@ export class Const {
 			[PageId.GIFT_CARD_BALANCE]: `${baseURL}/gift-card-balance`,
 			[PageId.LOYALTY_BALANCE]: `${baseURL}/loyalty-balance`,
 			[PageId.CLOSED_TICKETS]: `${baseURL}/closed-tickets`,
-			[PageId.APPOINTMENT]: `${baseURL}/appointment`,
+			[PageId.APPOINTMENT]: `${baseURL}/appointments`,
 			[PageId.TICKET_ADJUSTMENT]: `${baseURL}/management/ticket-adjustment`,
 		} as const;
 	}

--- a/e2e/pos-web/src/features/appointment.feature
+++ b/e2e/pos-web/src/features/appointment.feature
@@ -1,4 +1,4 @@
-@regression @smoke @skip
+@regression @smoke @slow
 Feature: Appointment
 
   Scenario: Create an appointment for an existing customer, edit to change technician and create ticket

--- a/e2e/pos-web/src/features/appointment.feature
+++ b/e2e/pos-web/src/features/appointment.feature
@@ -1,30 +1,7 @@
 @regression @smoke @skip
 Feature: Appointment
 
-  Scenario: Create an appointment for Any Technician of an existing customer
-    Given I am on the HOME page
-    When I navigate to "Appointment" on the navigation bar
-    Then I should be redirected to APPOINTMENT page
-
-    When I wait for the page fully loaded
-    And I select the "Any Technician" employee from the technician dropdown
-    Then I should see the title "Any Technician"
-
-    When I double click on the time slot at "07:00 AM"
-    Then I should see the "Create Appointment" screen
-    And I should see the "Manicure" service
-
-    When I add the "Manicure" service to my cart
-    Then I should see the service "Manicure" in my cart
-    And I should see the duration "20 minutes"
-
-    When I add the "Tin" customer
-    Then I should see a new customer "Tin" on ticket
-
-    When I click on the "SAVE" button
-    Then I should see the booked time at "07:00 AM - 07:20 AM"
-
-  Scenario: Create an appointment for a specific employee of a new customer
+  Scenario: Create an appointment for an existing customer, edit to change technician and create ticket
     Given I am on the HOME page
     When I navigate to "Appointment" on the navigation bar
     Then I should be redirected to APPOINTMENT page
@@ -41,15 +18,43 @@ Feature: Appointment
     Then I should see the service "Manicure" in my cart
     And I should see the duration "20 minutes"
 
-    When I click on the Select customer
-    And I click on the "Click Here To Add Customers" button
-    Then I should see a popup dialog with title "Create New Customer"
-    And I should see the loyalty program "2 Points = $1" visible
-
-    When I fill the new customer name "Booking"
-    And I fill the new customer phone
-    And I click on the "Save" button in the popup dialog
-    Then I should see a new customer "Booking" on ticket
+    When I add the "Tin" customer
+    Then I should see a new customer "Tin" on ticket
 
     When I click on the "SAVE" button
-    Then I should see the booked time at "07:00 AM - 07:20 AM"
+    And I handle the Confirm Validate Time dialog if it appears
+    Then I should see the customer "Tin" booked
+
+    When I select the booked of "Tin"
+    And I click on the "Edit" button
+    Then I should see the "Edit Appointment" screen
+    And I should see the service "Manicure" in my cart
+    And I should see the employee "Anna" in my cart
+    And I should see a new customer "Tin" on ticket
+    And I should see the time "07:00 AM" in my cart
+
+    When I select the service "Manicure" in my cart
+    Then I should see a popup dialog with title "Technician Multiple"
+    When I click on the "Addison" text inside the content section of the opening dialog
+    And I click on the "Apply" button in the dialog
+    Then I should see the "Addison" employee in my cart
+
+    When I click on the "SAVE" button
+    And I handle the Confirm Validate Time dialog if it appears
+    And I select the booked of "Tin"
+    And I click on the "Create Ticket" button
+    Then I should see the "Ticket View From Appointment" screen
+    And I should see the employee "Addison" in the ticket
+    And I should see the service "Manicure" in my cart
+    And I should see the employee "Addison" in my cart
+
+    When I click on the "PAY" button
+    Then I should see a popup dialog with title "Reward"
+    When I click on the "OK" button in the popup dialog
+
+    When I select the "Cash" payment type
+    And I click on the element with id "payment"
+    Then I should see a popup dialog with title "Close Ticket"
+    And I should see a popup dialog with content "CHANGE$0.00OK"
+    When I click on the "OK" button in the popup dialog
+    Then I should be redirected to HOME page

--- a/e2e/pos-web/src/features/check-in.feature
+++ b/e2e/pos-web/src/features/check-in.feature
@@ -18,7 +18,7 @@ Feature: Check In
 
     When I fill the new customer name "Check-in"
     And I fill the new customer phone
-    And I click on the "Save" button in the popup dialog
+    And I click on the "SAVE" button in the create new customer dialog
     Then I should see a new customer "Check-in" on ticket
 
     When I add the "Combo 1" service to my cart

--- a/e2e/pos-web/src/features/create-tickets.feature
+++ b/e2e/pos-web/src/features/create-tickets.feature
@@ -57,7 +57,7 @@ Feature: Create tickets
 
     When I fill the new customer name "Guest"
     And I fill the new customer phone
-    And I click on the "Save" button in the popup dialog
+    And I click on the "SAVE" button in the create new customer dialog
     Then I should see a new customer "Guest" on ticket
 
     When I click on the "PAY" button

--- a/e2e/pos-web/src/features/steps.ts
+++ b/e2e/pos-web/src/features/steps.ts
@@ -1109,13 +1109,13 @@ Then(
 );
 
 Then(
-	'I should see the booked time at {string}',
-	async ({ page }, time: string) => {
+	'I should see the customer {string} booked',
+	async ({ page }, customerName: string) => {
 		const appointmentElement = page
 			.locator('.e-appointment .event-cellTime')
 			.last();
 		await expect(appointmentElement).toBeVisible();
-		await expect(appointmentElement).toContainText(time);
+		await expect(appointmentElement).toContainText(customerName);
 	},
 );
 
@@ -1228,5 +1228,82 @@ When(
 			.getByText(employee, { exact: true });
 		await expect(employeeElement).toBeVisible();
 		await employeeElement.click();
+	},
+);
+
+When(
+	'I click on the {string} button in the create new customer dialog',
+	async ({ page }, button: string) => {
+		const buttonElement = page
+			.locator('.customDialogAction')
+			.getByRole('button', { name: button });
+		await buttonElement.click();
+	},
+);
+
+When(
+	'I select the booked of {string}',
+	async ({ page }, customerName: string) => {
+		const appointmentElement = page
+			.locator('.e-appointment .event-cellTime')
+			.last();
+		await expect(appointmentElement).toBeVisible();
+		await expect(appointmentElement).toContainText(customerName);
+		await appointmentElement.click();
+	},
+);
+
+Then(
+	'I should see the time {string} in my cart',
+	async ({ page }, time: string) => {
+		const timeElement = page
+			.locator('.dateBooking')
+			.getByText(time, { exact: true });
+		await expect(timeElement).toBeVisible();
+		await expect(timeElement).toContainText(time);
+	},
+);
+
+When(
+	'I handle the Confirm Validate Time dialog if it appears',
+	async ({ page }) => {
+		// Wait a short time to ensure page is stable
+		await page.waitForTimeout(500);
+
+		// Check if any dialog is visible
+		const dialogVisible = await page.locator('div[role="dialog"]').isVisible();
+
+		if (dialogVisible) {
+			// Look for the confirm button with the specific class from the HTML
+			const confirmButton = page
+				.locator('button.MuiButton-containedPrimary.button_dialog_options')
+				.getByRole('button', { name: 'SIGN IN', exact: true });
+
+			// Check if the confirm button is visible
+			const confirmButtonVisible = await confirmButton.isVisible();
+
+			if (confirmButtonVisible) {
+				// Click the confirm button
+				await confirmButton.click({ force: true });
+
+				// Wait for dialog to disappear
+				await page
+					.waitForSelector('div[role="dialog"]', {
+						state: 'hidden',
+						timeout: 5000,
+					})
+					.catch(() => {
+						// If dialog doesn't disappear, try clicking again
+						return confirmButton
+							.click({ force: true, timeout: 2000 })
+							.catch(() => {});
+					});
+
+				// Wait for page to update
+				await page.waitForLoadState('networkidle');
+			}
+		}
+
+		// If no dialog is visible, this step completes without doing anything
 	},
 );

--- a/e2e/pos-web/src/features/steps.ts
+++ b/e2e/pos-web/src/features/steps.ts
@@ -1274,7 +1274,7 @@ When(
 		const dialogVisible = await page.locator('div[role="dialog"]').isVisible();
 
 		if (dialogVisible) {
-			// Look for the confirm button with the specific class from the HTML
+			// Look for the confirm button
 			const confirmButton = page
 				.locator('button.MuiButton-containedPrimary.button_dialog_options')
 				.getByRole('button', { name: 'SIGN IN', exact: true });

--- a/e2e/pos-web/src/features/steps.ts
+++ b/e2e/pos-web/src/features/steps.ts
@@ -1273,37 +1273,14 @@ When(
 		// Check if any dialog is visible
 		const dialogVisible = await page.locator('div[role="dialog"]').isVisible();
 
-		if (dialogVisible) {
+		if (dialogVisible === true) {
 			// Look for the confirm button
 			const confirmButton = page
 				.locator('button.MuiButton-containedPrimary.button_dialog_options')
-				.getByRole('button', { name: 'SIGN IN', exact: true });
-
-			// Check if the confirm button is visible
-			const confirmButtonVisible = await confirmButton.isVisible();
-
-			if (confirmButtonVisible) {
-				// Click the confirm button
-				await confirmButton.click({ force: true });
-
-				// Wait for dialog to disappear
-				await page
-					.waitForSelector('div[role="dialog"]', {
-						state: 'hidden',
-						timeout: 5000,
-					})
-					.catch(() => {
-						// If dialog doesn't disappear, try clicking again
-						return confirmButton
-							.click({ force: true, timeout: 2000 })
-							.catch(() => {});
-					});
-
-				// Wait for page to update
-				await page.waitForLoadState('networkidle');
-			}
+				.getByRole('button', { name: 'confirm', exact: true });
+			await expect(confirmButton).toBeVisible();
+			await confirmButton.click({ force: true });
 		}
-
 		// If no dialog is visible, this step completes without doing anything
 	},
 );


### PR DESCRIPTION
## Summary by Sourcery

Update and expand end-to-end tests for the appointment feature, covering editing appointments, changing technicians, creating tickets from appointments, and handling a confirmation dialog. Fix the appointment page URL constant.

Bug Fixes:
- Correct the URL path constant for the appointment page from `/appointment` to `/appointments`.
- Update button name in the create new customer dialog step definition to 'SAVE' for consistency across tests

Tests:
- Expand the main appointment E2E test scenario to cover editing appointments, changing technicians, and creating tickets.
- Add steps to handle a potential 'Confirm Validate Time' dialog that may appear after saving or editing appointments.
- Update appointment booking assertions to verify the customer's name instead of the time slot.
- Add new step definitions for selecting booked appointments by customer name and verifying time in the cart.
- Refactor the step definition for clicking the save button in the 'Create New Customer' dialog.