### PR TITLE
feat(pos-web): add steps verify display categories and services in check-in

### DIFF
--- a/e2e/pos-web/src/features/check-in.feature
+++ b/e2e/pos-web/src/features/check-in.feature
@@ -9,6 +9,9 @@ Feature: Check In
 
     When I click on the "Add Customer" button in the waiting page
     Then I should see the text "Create Waiting" visible
+    When I wait for the page fully loaded
+    Then I should see the categories displayed correctly in check-in
+    And I should see the services displayed correctly in check-in
     And I should see the "Next Available Service" service
 
     When I click on the Select customer
@@ -65,6 +68,9 @@ Feature: Check In
 
     When I click on the "Add Customer" button
     Then I should see the text "Create Waiting" visible
+    When I wait for the page fully loaded
+    Then I should see the categories displayed correctly in check-in
+    And I should see the services displayed correctly in check-in
     And I should see the "Next Available Service" service
 
     When I add the "Alice" customer

--- a/e2e/pos-web/src/features/check-in.feature
+++ b/e2e/pos-web/src/features/check-in.feature
@@ -9,7 +9,6 @@ Feature: Check In
 
     When I click on the "Add Customer" button in the waiting page
     Then I should see the text "Create Waiting" visible
-    When I wait for the page fully loaded
     Then I should see the categories displayed correctly in check-in
     And I should see the services displayed correctly in check-in
     And I should see the "Next Available Service" service
@@ -37,7 +36,6 @@ Feature: Check In
     When I click on the "SAVE" button
     Then I should be redirected to WAITING_LIST page
 
-    When I wait for the page fully loaded
     Then I should see the customer "Check-in" in the waiting list
     And I should see the service "Combo 1" in the waiting list
     And I should see the technician "Any Technician" in the waiting list
@@ -62,14 +60,12 @@ Feature: Check In
 
   Scenario: Create a waiting for existing customer, assign services to specific employees and create ticket
     Given I am on the HOME page
-    When I wait for the page fully loaded
-    And I click on the "Check In" label in the header
+    When I click on the "Check In" label in the header
     Then I should be redirected to WAITING_LIST page
 
     When I click on the "Add Customer" button
     Then I should see the text "Create Waiting" visible
-    When I wait for the page fully loaded
-    Then I should see the categories displayed correctly in check-in
+    And I should see the categories displayed correctly in check-in
     And I should see the services displayed correctly in check-in
     And I should see the "Next Available Service" service
 
@@ -92,7 +88,6 @@ Feature: Check In
     When I click on the "SAVE" button
     Then I should be redirected to WAITING_LIST page
 
-    When I wait for the page fully loaded
     Then I should see the customer "Alice" in the waiting list
     And I should see the service "Manicure" in the waiting list
     And I should see the service "Pedicure" in the waiting list

--- a/e2e/pos-web/src/features/steps.ts
+++ b/e2e/pos-web/src/features/steps.ts
@@ -1230,3 +1230,47 @@ When(
 		await employeeElement.click();
 	},
 );
+
+Then(
+	'I should see the categories displayed correctly in check-in',
+	async ({ page }) => {
+		const expectedCategories = ['MANI & PEDI', 'FULL SET & FILL IN'];
+
+		const categoryElements = page.locator('[role="tablist"] span');
+		await expect(categoryElements).toHaveCount(expectedCategories.length);
+
+		for (let i = 0; i < expectedCategories.length; i++) {
+			const categoryName = await categoryElements.nth(i).innerText();
+			expect(categoryName.trim()).toBe(expectedCategories[i]);
+		}
+	},
+);
+
+Then(
+	'I should see the services displayed correctly in check-in',
+	async ({ page }) => {
+		const expectedServices = [
+			'Next Available Service',
+			'Manicure',
+			'Pedicure',
+			'Cut cuticle',
+			'Gel removal',
+			'Acrylic removal',
+			'Gel X',
+			'Request price',
+			'Combo 1',
+			'Combo 2',
+			'Supper combo',
+		];
+
+		const serviceElements = page.locator(
+			'li.ItemService .ItemService__name span',
+		);
+		await expect(serviceElements).toHaveCount(expectedServices.length);
+
+		for (let i = 0; i < expectedServices.length; i++) {
+			const serviceName = await serviceElements.nth(i).innerText();
+			expect(serviceName.trim()).toBe(expectedServices[i]);
+		}
+	},
+);


### PR DESCRIPTION
## Summary by Sourcery

Add end-to-end tests to verify the display of service categories and services during the check-in process.

Tests:
- Verify that the expected service categories are displayed correctly on the check-in screen.
- Verify that the expected services are displayed correctly on the check-in screen.