### PR TITLE
feat(pos-web): add test cases in check-in feature

### DIFF
--- a/e2e/pos-web/src/features/appointment.feature
+++ b/e2e/pos-web/src/features/appointment.feature
@@ -1,6 +1,6 @@
 @regression @smoke @slow
 Feature: Appointment
-
+  @skip
   Scenario: Create an appointment for an existing customer, edit to change technician and create ticket
     Given I am on the HOME page
     When I navigate to "Appointment" on the navigation bar
@@ -59,7 +59,6 @@ Feature: Appointment
     When I click on the "OK" button in the popup dialog
     Then I should be redirected to HOME page
 
-  @skip
   Scenario: Create an appointment for a new customer, edit to change technician and create ticket
     Given I am on the HOME page
     When I navigate to "Appointment" on the navigation bar

--- a/e2e/pos-web/src/features/check-in.feature
+++ b/e2e/pos-web/src/features/check-in.feature
@@ -117,3 +117,249 @@ Feature: Check In
     And I fill the last 4 digits of card number "1234"
     And I click on the element with id "payment"
     Then I should be redirected to HOME page
+
+  Scenario: Display service hint in ticket view
+    Given I am on the HOME page
+    When I wait for the page fully loaded
+    And I click on the "Check In" label in the header
+    Then I should be redirected to WAITING_LIST page
+
+    When I click on the "Add Customer" button in the waiting page
+    Then I should see the text "Create Waiting" visible
+    Then I should see the categories displayed correctly in check-in
+    And I should see the services displayed correctly in check-in
+    And I should see the "Next Available Service" service
+
+    When I click on the Select customer
+    And I click on the "Click Here To Add Customers" button
+    Then I should see a popup dialog with title "Create New Customer"
+    And I should see the loyalty program "2 Points = $1" visible
+
+    When I fill the new customer name "Waiting"
+    And I fill the new customer phone
+    And I click on the "SAVE" button in the create new customer dialog
+    Then I should see a new customer "Waiting" on ticket
+
+    When I add the "Next Available Service" service to my cart
+    Then I should see a popup dialog with title "Pick Technician"
+    When I click on the "Next Available" text inside the content section of the opening dialog
+    Then I should see the service "MANI & PEDI" in my cart
+    And I should see the employee "Next Available" in my cart
+
+    When I click on the "SAVE" button
+    Then I should be redirected to WAITING_LIST page
+
+    Then I should see the customer "Waiting" in the waiting list
+    And I should see the service "MANI & PEDI" in the waiting list
+    And I should see the technician "Next Available" in the waiting list
+
+    When I click on the last row for customer "Waiting" to expand details
+    Then I should see the "Create Ticket" button visible
+
+    When I click on the "Create Ticket" button
+    Then I should see the "Ticket View" screen
+    And I should see the employee "Anna" in the ticket
+    And I should see the service hint
+    And I should see the hint details "MANI & PEDI (Next Available)"
+
+    When I add the "Acrylic removal" service to my cart
+    Then I should see my cart showing 1 item added
+    And I should see the tax amount non-zero
+    And I should see the "Anna" employee in my cart
+
+    When I click on the "PAY" button
+    Then I should see the text "PAYMENT TICKET" visible
+    And I should see the text "PAYMENT HISTORY" visible
+    And I should see the button with id "payment" visible
+
+    When I click on the element with id "payment"
+    Then I should see a popup dialog with title "Close Ticket"
+    And I should see a popup dialog with content "CHANGE$0.00OK"
+    When I click on the "OK" button in the popup dialog
+    Then I should be redirected to HOME page
+
+  Scenario: Editing a waiting to add service and create ticket
+    Given I am on the HOME page
+    When I wait for the page fully loaded
+    And I click on the "Check In" label in the header
+    Then I should be redirected to WAITING_LIST page
+
+    When I click on the "Add Customer" button in the waiting page
+    Then I should see the text "Create Waiting" visible
+    Then I should see the categories displayed correctly in check-in
+    And I should see the services displayed correctly in check-in
+    And I should see the "Next Available Service" service
+
+    When I click on the Select customer
+    And I click on the "Click Here To Add Customers" button
+    Then I should see a popup dialog with title "Create New Customer"
+    And I should see the loyalty program "2 Points = $1" visible
+
+    When I fill the new customer name "Editing"
+    And I fill the new customer phone
+    And I click on the "SAVE" button in the create new customer dialog
+    Then I should see a new customer "Editing" on ticket
+
+    When I add the "Gel X" service to my cart
+    Then I should see a popup dialog with title "Pick Technician"
+    When I click on the "Any Technician" text inside the content section of the opening dialog
+    Then I should see the service "Gel X" in my cart
+    And I should see the duration "30 mins" in my cart
+    And I should see the employee "Any Technician" in my cart
+
+    When I click on the "SAVE" button
+    Then I should be redirected to WAITING_LIST page
+
+    Then I should see the customer "Editing" in the waiting list
+    And I should see the service "Gel X" in the waiting list
+    And I should see the technician "Any Technician" in the waiting list
+
+    When I click on the last row for customer "Editing" to expand details
+    Then I should see the "Edit" button visible
+
+    When I click on the "Edit" button
+    Then I should see the "Edit Waiting" screen
+    And I should see a new customer "Editing" on ticket
+    And I should see the service "Gel X" in my cart
+    And I should see the employee "Any Technician" in my cart
+
+    When I add the "Pedicure" service to my cart
+    Then I should see a popup dialog with title "Pick Technician"
+    When I click on the "Any Technician" text inside the content section of the opening dialog
+    Then I should see the service "Pedicure" in my cart
+    And I should see the duration "25 mins" in my cart
+    And I should see multiple "Any Technician" employees in my cart
+
+    When I click on the "SAVE" button
+    Then I should be redirected to WAITING_LIST page
+    And I should see the customer "Editing" in the waiting list
+    And I should see the service "Gel X" in the waiting list
+    And I should see the technician "Any Technician" in the waiting list
+
+    When I click on the last row for customer "Editing" to expand details
+    Then I should see the "Create Ticket" button visible
+
+    When I click on the "Create Ticket" button
+    Then I should see the "Ticket View" screen
+    And I should see the employee "Anna" in the ticket
+
+    When I click on the "PAY" button
+    Then I should see the text "PAYMENT TICKET" visible
+    And I should see the text "PAYMENT HISTORY" visible
+    And I should see the button with id "payment" visible
+
+    When I click on the element with id "payment"
+    Then I should see a popup dialog with title "Close Ticket"
+    And I should see a popup dialog with content "CHANGE$0.00OK"
+    When I click on the "OK" button in the popup dialog
+    Then I should be redirected to HOME page
+
+  Scenario: Make appointment for Next Available Service and fill duration
+    Given I am on the HOME page
+    When I wait for the page fully loaded
+    And I click on the "Check In" label in the header
+    Then I should be redirected to WAITING_LIST page
+
+    When I click on the "Add Customer" button in the waiting page
+    Then I should see the text "Create Waiting" visible
+    Then I should see the categories displayed correctly in check-in
+    And I should see the services displayed correctly in check-in
+    And I should see the "Next Available Service" service
+
+    When I click on the Select customer
+    And I click on the "Click Here To Add Customers" button
+    Then I should see a popup dialog with title "Create New Customer"
+    And I should see the loyalty program "2 Points = $1" visible
+
+    When I fill the new customer name "Duration"
+    And I fill the new customer phone
+    And I click on the "SAVE" button in the create new customer dialog
+    Then I should see a new customer "Duration" on ticket
+
+    When I add the "Next Available Service" service to my cart
+    Then I should see a popup dialog with title "Pick Technician"
+    When I click on the "Next Available" text inside the content section of the opening dialog
+    Then I should see the service "MANI & PEDI" in my cart
+    And I should see the employee "Next Available" in my cart
+
+    When I click on the "SAVE" button
+    Then I should be redirected to WAITING_LIST page
+
+    Then I should see the customer "Duration" in the waiting list
+    And I should see the service "MANI & PEDI" in the waiting list
+    And I should see the technician "Next Available" in the waiting list
+
+    When I click on the last row for customer "Duration" to expand details
+    Then I should see the "Create Ticket" button visible
+
+    When I click on the "Make Appt" button
+    Then I should see a popup dialog with title "ENTER DURATION"
+    When I enter the amount "10"
+    And I click on the "OK" button in the popup dialog
+    Then I should see the pin appointment
+
+    When I click on the "Create Ticket" button
+    Then I should see the "Ticket View From Appointment" screen
+    And I should see the employee "Anna" in the ticket
+    And I should see the service hint
+    And I should see the hint details "MANI & PEDI (Next Available)"
+
+    When I add the "Acrylic removal" service to my cart
+    Then I should see my cart showing 1 item added
+    And I should see the tax amount non-zero
+    And I should see the "Anna" employee in my cart
+
+    When I click on the "PAY" button
+    Then I should see the text "PAYMENT TICKET" visible
+    And I should see the text "PAYMENT HISTORY" visible
+    And I should see the button with id "payment" visible
+
+    When I click on the element with id "payment"
+    Then I should see a popup dialog with title "Close Ticket"
+    And I should see a popup dialog with content "CHANGE$0.00OK"
+    When I click on the "OK" button in the popup dialog
+    Then I should be redirected to HOME page
+
+  Scenario: Delete a waiting
+    Given I am on the HOME page
+    When I wait for the page fully loaded
+    And I click on the "Check In" label in the header
+    Then I should be redirected to WAITING_LIST page
+
+    When I click on the "Add Customer" button in the waiting page
+    Then I should see the text "Create Waiting" visible
+    Then I should see the categories displayed correctly in check-in
+    And I should see the services displayed correctly in check-in
+    And I should see the "Next Available Service" service
+
+    When I click on the Select customer
+    And I click on the "Click Here To Add Customers" button
+    Then I should see a popup dialog with title "Create New Customer"
+    And I should see the loyalty program "2 Points = $1" visible
+
+    When I fill the new customer name "Delete"
+    And I fill the new customer phone
+    And I click on the "SAVE" button in the create new customer dialog
+    Then I should see a new customer "Delete" on ticket
+
+    When I add the "Next Available Service" service to my cart
+    Then I should see a popup dialog with title "Pick Technician"
+    When I click on the "Next Available" text inside the content section of the opening dialog
+    Then I should see the service "MANI & PEDI" in my cart
+    And I should see the employee "Next Available" in my cart
+
+    When I click on the "SAVE" button
+    Then I should be redirected to WAITING_LIST page
+
+    Then I should see the customer "Delete" in the waiting list
+    And I should see the service "MANI & PEDI" in the waiting list
+    And I should see the technician "Next Available" in the waiting list
+
+    When I click on the last row for customer "Delete" to expand details
+    Then I should see the "Create Ticket" button visible
+
+    When I click on the "Delete" button
+    Then I should see a popup dialog with title "Remove Confirmation"
+    When I click on the "confirm" button in the popup dialog
+    Then I should not see the customer "Delete" in the waiting list
+

--- a/e2e/pos-web/src/features/steps.ts
+++ b/e2e/pos-web/src/features/steps.ts
@@ -999,21 +999,30 @@ When(
 
 		// Define the time slot map with proper typing
 		const timeSlotMap: Record<string, number> = {
-			'07:00 AM': 1,
-			'08:00 AM': 2,
-			'09:00 AM': 3,
-			'10:00 AM': 4,
-			'11:00 AM': 5,
-			'12:00 PM': 6,
-			'01:00 PM': 7,
-			'02:00 PM': 8,
-			'03:00 PM': 9,
-			'04:00 PM': 10,
-			'05:00 PM': 11,
-			'06:00 PM': 12,
-			'07:00 PM': 13,
-			'08:00 PM': 14,
-			'09:00 PM': 15,
+			'12:00 AM': 1,
+			'01:00 AM': 2,
+			'02:00 AM': 3,
+			'03:00 AM': 4,
+			'04:00 AM': 5,
+			'05:00 AM': 6,
+			'06:00 AM': 7,
+			'07:00 AM': 8,
+			'08:00 AM': 9,
+			'09:00 AM': 10,
+			'10:00 AM': 11,
+			'11:00 AM': 12,
+			'12:00 PM': 13,
+			'01:00 PM': 14,
+			'02:00 PM': 15,
+			'03:00 PM': 16,
+			'04:00 PM': 17,
+			'05:00 PM': 18,
+			'06:00 PM': 19,
+			'07:00 PM': 20,
+			'08:00 PM': 21,
+			'09:00 PM': 22,
+			'10:00 PM': 23,
+			'11:00 PM': 24,
 		};
 
 		// Get the row index from the specified time slot
@@ -1437,5 +1446,34 @@ Then(
 			.locator('.MuiBox-root')
 			.getByRole('button', { name: text });
 		await expect(buttonElement).toBeVisible();
+	},
+);
+
+Then('I should see the service hint', async ({ page }) => {
+	const serviceHint = page.locator('[data-testid="QuestionMarkIcon"]');
+	await expect(serviceHint).toBeVisible();
+});
+
+Then(
+	'I should see the hint details {string}',
+	async ({ page }, text: string) => {
+		const hintDetails = page.locator('.MuiTypography-root').getByText(text);
+		await expect(hintDetails).toBeVisible();
+		await expect(hintDetails).toContainText(text);
+	},
+);
+
+Then('I should see the pin appointment', async ({ page }) => {
+	const pinAppointment = page.locator('.xWaitingList__item--label');
+	await expect(pinAppointment).toBeVisible();
+});
+
+Then(
+	'I should not see the customer {string} in the waiting list',
+	async ({ page }, customer: string) => {
+		const customerElement = page
+			.locator('div[data-field="customerInfo"]')
+			.getByText(customer, { exact: true });
+		await expect(customerElement).not.toBeVisible();
 	},
 );

--- a/e2e/pos-web/src/features/steps.ts
+++ b/e2e/pos-web/src/features/steps.ts
@@ -993,59 +993,32 @@ When(
 	'I double click on the time slot at {string}',
 	async ({ page }, timeSlot: string) => {
 		await page.waitForLoadState('networkidle', { timeout: 60000 });
-
-		// Wait for DOM to be fully loaded
 		await page.waitForLoadState('domcontentloaded', { timeout: 60000 });
 
-		// Define the time slot map with proper typing
-		const timeSlotMap: Record<string, number> = {
-			'12:00 AM': 1,
-			'01:00 AM': 2,
-			'02:00 AM': 3,
-			'03:00 AM': 4,
-			'04:00 AM': 5,
-			'05:00 AM': 6,
-			'06:00 AM': 7,
-			'07:00 AM': 8,
-			'08:00 AM': 9,
-			'09:00 AM': 10,
-			'10:00 AM': 11,
-			'11:00 AM': 12,
-			'12:00 PM': 13,
-			'01:00 PM': 14,
-			'02:00 PM': 15,
-			'03:00 PM': 16,
-			'04:00 PM': 17,
-			'05:00 PM': 18,
-			'06:00 PM': 19,
-			'07:00 PM': 20,
-			'08:00 PM': 21,
-			'09:00 PM': 22,
-			'10:00 PM': 23,
-			'11:00 PM': 24,
-		};
+		// Dynamically generate time slot map
+		const timeSlotMap: Record<string, number> = {};
+		for (let hour = 0; hour < 24; hour++) {
+			const hour12 = hour % 12 === 0 ? 12 : hour % 12;
+			const period = hour < 12 ? 'AM' : 'PM';
+			const label = `${hour12.toString().padStart(2, '0')}:00 ${period}`;
+			timeSlotMap[label] = hour + 1;
+		}
 
-		// Get the row index from the specified time slot
 		const rowIndex = timeSlotMap[timeSlot];
 
-		// Validate the provided time slot
 		if (!rowIndex) {
 			throw new Error(
 				`Time slot "${timeSlot}" is not valid. Valid options are: ${Object.keys(timeSlotMap).join(', ')}`,
 			);
 		}
 
-		// Find the row corresponding to the time slot (using nth which is 0-based)
 		const targetRow = page
 			.locator('#scheduler_table tbody tr')
 			.nth(rowIndex - 1);
-
 		const targetCell = targetRow.locator('td.e-work-cells');
 
 		await expect(targetCell).toBeVisible({ timeout: 60000 });
-
 		await targetCell.scrollIntoViewIfNeeded();
-
 		await targetCell.dblclick();
 	},
 );


### PR DESCRIPTION
## Summary by Sourcery

Add comprehensive E2E tests for the POS web check-in feature, extend test step definitions and time slot mapping, and adjust test tagging in appointment scenarios.

Enhancements:
- Extend time slot mapping in test steps to cover all hours from 00:00 to 23:00.

Tests:
- Add new check-in scenarios for service hint display, editing a waiting, making an appointment with duration, and deleting a waiting entry.
- Implement new step definitions to verify service hints, hint details, pinned appointments, and absence of customers in the waiting list.
- Toggle @skip tags in appointment.feature to control execution of specific appointment scenarios.