### PR TITLE
feat(pos-web): update test cases clock-in and clock-in others in the timesheet

### DIFF
--- a/e2e/pos-web/src/features/appointment.feature
+++ b/e2e/pos-web/src/features/appointment.feature
@@ -209,7 +209,7 @@ Feature: Appointment
     When I select the "Anna" employee from the technician dropdown
     Then I should see the title "Anna"
 
-    When I double click on the time slot at "10:00 AM"
+    When I double click on the time slot at "06:00 AM"
     Then I should see the "Create Appointment" screen
     And I should see the "Manicure" service
 
@@ -252,14 +252,14 @@ Feature: Appointment
 
     When I wait for the page fully loaded
     Then I should see the title "Any Technician"
-    When I select the last booking in the time slot at "10:00 AM"
+    When I select the last booking in the time slot at "06:00 AM"
     And I click on the "Edit" button
 
     Then I should see the "Edit Appointment" screen
     And I should see the service "Manicure" in my cart
     And I should see the employee "Anna" in my cart
     And I should see a new customer "Booking" on ticket
-    And I should see the time "10:00 AM" in my cart
+    And I should see the time "06:00 AM" in my cart
     And I should see the appointment status "Chosen Tech"
     And I should see the appointment status "None"
     And I should see the appointment status "Completed"

--- a/e2e/pos-web/src/features/check-in.feature
+++ b/e2e/pos-web/src/features/check-in.feature
@@ -151,7 +151,6 @@ Feature: Check In
 
     Then I should see the customer "Waiting" in the waiting list
     And I should see the service "MANI & PEDI" in the waiting list
-    And I should see the technician "Next Available" in the waiting list
 
     When I click on the last row for customer "Waiting" to expand details
     Then I should see the "Create Ticket" button visible
@@ -202,17 +201,17 @@ Feature: Check In
 
     When I add the "Gel X" service to my cart
     Then I should see a popup dialog with title "Pick Technician"
-    When I click on the "Any Technician" text inside the content section of the opening dialog
+    When I click on the "Addison" text inside the content section of the opening dialog
     Then I should see the service "Gel X" in my cart
     And I should see the duration "30 mins" in my cart
-    And I should see the employee "Any Technician" in my cart
+    And I should see the employee "Addison" in my cart
 
     When I click on the "SAVE" button
     Then I should be redirected to WAITING_LIST page
 
     Then I should see the customer "Editing" in the waiting list
     And I should see the service "Gel X" in the waiting list
-    And I should see the technician "Any Technician" in the waiting list
+    And I should see the technician "Addison" in the waiting list
 
     When I click on the last row for customer "Editing" to expand details
     Then I should see the "Edit" button visible
@@ -221,27 +220,27 @@ Feature: Check In
     Then I should see the "Edit Waiting" screen
     And I should see a new customer "Editing" on ticket
     And I should see the service "Gel X" in my cart
-    And I should see the employee "Any Technician" in my cart
+    And I should see the employee "Addison" in my cart
 
-    When I add the "Pedicure" service to my cart
+    When I add the "Cut cuticle" service to my cart
     Then I should see a popup dialog with title "Pick Technician"
-    When I click on the "Any Technician" text inside the content section of the opening dialog
-    Then I should see the service "Pedicure" in my cart
+    When I click on the "Addison" text inside the content section of the opening dialog
+    Then I should see the service "Cut cuticle" in my cart
     And I should see the duration "25 mins" in my cart
-    And I should see multiple "Any Technician" employees in my cart
+    And I should see multiple "Addison" employees in my cart
 
     When I click on the "SAVE" button
     Then I should be redirected to WAITING_LIST page
     And I should see the customer "Editing" in the waiting list
     And I should see the service "Gel X" in the waiting list
-    And I should see the technician "Any Technician" in the waiting list
+    And I should see the service "Cut cuticle" in the waiting list
 
     When I click on the last row for customer "Editing" to expand details
     Then I should see the "Create Ticket" button visible
 
     When I click on the "Create Ticket" button
     Then I should see the "Ticket View" screen
-    And I should see the employee "Anna" in the ticket
+    And I should see the employee "Addison" in the ticket
 
     When I click on the "PAY" button
     Then I should see the text "PAYMENT TICKET" visible
@@ -276,18 +275,18 @@ Feature: Check In
     And I click on the "SAVE" button in the create new customer dialog
     Then I should see a new customer "Duration" on ticket
 
+    When I select the "FULL SET & FILL IN" category
     When I add the "Next Available Service" service to my cart
     Then I should see a popup dialog with title "Pick Technician"
     When I click on the "Next Available" text inside the content section of the opening dialog
-    Then I should see the service "MANI & PEDI" in my cart
+    Then I should see the service "FULL SET & FILL IN" in my cart
     And I should see the employee "Next Available" in my cart
 
     When I click on the "SAVE" button
     Then I should be redirected to WAITING_LIST page
 
     Then I should see the customer "Duration" in the waiting list
-    And I should see the service "MANI & PEDI" in the waiting list
-    And I should see the technician "Next Available" in the waiting list
+    And I should see the service "FULL SET & FILL IN" in the waiting list
 
     When I click on the last row for customer "Duration" to expand details
     Then I should see the "Create Ticket" button visible
@@ -302,7 +301,7 @@ Feature: Check In
     Then I should see the "Ticket View From Appointment" screen
     And I should see the employee "Anna" in the ticket
     And I should see the service hint
-    And I should see the hint details "MANI & PEDI (Next Available)"
+    And I should see the hint details "FULL SET & FILL IN (Next Available)"
 
     When I add the "Acrylic removal" service to my cart
     Then I should see my cart showing 1 item added
@@ -342,18 +341,18 @@ Feature: Check In
     And I click on the "SAVE" button in the create new customer dialog
     Then I should see a new customer "Delete" on ticket
 
-    When I add the "Next Available Service" service to my cart
+    When I select the "ADDITIONAL SERVICE" category
+    And I add the "Next Available Service" service to my cart
     Then I should see a popup dialog with title "Pick Technician"
     When I click on the "Next Available" text inside the content section of the opening dialog
-    Then I should see the service "MANI & PEDI" in my cart
+    Then I should see the service "ADDITIONAL SERVICE" in my cart
     And I should see the employee "Next Available" in my cart
 
     When I click on the "SAVE" button
     Then I should be redirected to WAITING_LIST page
 
     Then I should see the customer "Delete" in the waiting list
-    And I should see the service "MANI & PEDI" in the waiting list
-    And I should see the technician "Next Available" in the waiting list
+    And I should see the service "ADDITIONAL SERVICE" in the waiting list
 
     When I click on the last row for customer "Delete" to expand details
     Then I should see the "Create Ticket" button visible

--- a/e2e/pos-web/src/features/create-tickets.feature
+++ b/e2e/pos-web/src/features/create-tickets.feature
@@ -53,7 +53,6 @@ Feature: Create tickets
     When I select the "Dylan" employee
     And I add the "Manicure" service to my cart
     Then I should see my cart showing 1 item added
-    And I should see the tax amount non-zero
 
     When I click on the Select customer
     And I click on the "Click Here To Add Customers" button
@@ -86,7 +85,6 @@ Feature: Create tickets
     When I add the "Manicure" service to my cart
     When I add the "Pedicure" service to my cart
     Then I should see my cart showing 2 item added
-    And I should see the tax amount non-zero
 
     When I click on the item "Technician" button
     Then I should see a popup dialog with title "TECHNICIAN MULTIPLE"
@@ -116,7 +114,6 @@ Feature: Create tickets
 
     When I add the "Manicure" service to my cart
     Then I should see my cart showing 1 item added
-    And I should see the tax amount non-zero
 
     When I click on the adding "Tip" button
     Then I should see a popup dialog with title "Add Tip"
@@ -142,7 +139,6 @@ Feature: Create tickets
 
     When I add the "Manicure" service to my cart
     Then I should see my cart showing 1 item added
-    And I should see the tax amount non-zero
 
     When I click on the "PAY" button
     Then I should see the text "PAYMENT TICKET" visible
@@ -165,7 +161,6 @@ Feature: Create tickets
 
     When I add the "Manicure" service to my cart
     Then I should see my cart showing 1 item added
-    And I should see the tax amount non-zero
 
     When I click on the "PAY" button
     Then I should see the text "PAYMENT TICKET" visible
@@ -186,7 +181,6 @@ Feature: Create tickets
     When I add the "Manicure" service to my cart
     When I add the "Pedicure" service to my cart
     Then I should see my cart showing 2 item added
-    And I should see the tax amount non-zero
 
     When I click on the item "Technician" button
     Then I should see a popup dialog with title "TECHNICIAN MULTIPLE"
@@ -228,7 +222,6 @@ Feature: Create tickets
 
     When I add the "Gel removal" service to my cart
     Then I should see my cart showing 1 item added
-    And I should see the tax amount non-zero
 
     When I click on the "PAY" button
     Then I should see the text "PAYMENT TICKET" visible
@@ -252,7 +245,6 @@ Feature: Create tickets
 
     When I add the "Acrylic removal" service to my cart
     Then I should see my cart showing 1 item added
-    And I should see the tax amount non-zero
 
     When I click on the "PAY" button
     Then I should see the text "PAYMENT TICKET" visible
@@ -285,7 +277,6 @@ Feature: Create tickets
 
     When I add the "Manicure" service to my cart
     Then I should see my cart showing 1 item added
-    And I should see the tax amount non-zero
 
     When I click on the total price of "Manicure"
     Then I should see a popup dialog with title "Service: Manicure - $6.00"
@@ -316,7 +307,6 @@ Feature: Create tickets
 
     When I add the "Manicure" service to my cart
     Then I should see my cart showing 1 item added
-    And I should see the tax amount non-zero
 
     When I click on the item "DISCOUNT ITEM" button
     Then I should see a popup dialog with title "DISCOUNT MULTIPLE"
@@ -354,7 +344,6 @@ Feature: Create tickets
 
     When I add the "Manicure" service to my cart
     Then I should see my cart showing 1 item added
-    And I should see the tax amount non-zero
 
     When I click on the adding "Discount" button
     Then I should see a popup dialog with title "Add Discount Ticket"
@@ -396,7 +385,6 @@ Feature: Create tickets
     When I click on the "ADD ON" button in the popup dialog
     Then I should see my cart showing 1 item added
     And I should see the service "Gift card $100 (1234)" in my cart
-    And I should see the tax amount non-zero
 
     When I click on the "PAY" button
     Then I should see the text "PAYMENT TICKET" visible
@@ -576,7 +564,6 @@ Feature: Create tickets
     When I add the "Pedicure" service to my cart
     Then I should see my cart showing 2 item added
     And I should see the service "Pedicure" in my cart
-    And I should see the tax amount non-zero
 
     When I click on the "PAY" button
     Then I should see the text "PAYMENT TICKET" visible
@@ -600,7 +587,6 @@ Feature: Create tickets
 
     When I add the "Combo 1" service to my cart
     Then I should see my cart showing 1 item added
-    And I should see the tax amount non-zero
     And I should see the service "Manicure" in my cart
     And I should see the service "Pedicure" in my cart
     And I should see multiple "Sophia" employees in my cart
@@ -635,7 +621,6 @@ Feature: Create tickets
 
     When I add the "Combo 1" service to my cart
     Then I should see my cart showing 1 item added
-    And I should see the tax amount non-zero
     And I should see the service "Manicure" in my cart
     And I should see the service "Pedicure" in my cart
     And I should see multiple "Mia" employees in my cart

--- a/e2e/pos-web/src/features/steps.ts
+++ b/e2e/pos-web/src/features/steps.ts
@@ -236,6 +236,17 @@ Then(
 	},
 );
 
+Then(
+	'I should see multiple {string} technicians in the waiting list',
+	async ({ page }, technician: string) => {
+		const technicianElements = await page
+			.locator('div[data-field="technicianNickNames"]')
+			.getByText(technician, { exact: true })
+			.all();
+		expect(technicianElements.length).toBeGreaterThan(1);
+	},
+);
+
 Then('I should see the {string} name', async ({ page }, name: string) => {
 	const nameElement = page.locator('.xPayment__card--input').getByText(name);
 	await expect(nameElement).toContainText(name);
@@ -1300,7 +1311,11 @@ Then(
 Then(
 	'I should see the categories displayed correctly in check-in',
 	async ({ page }) => {
-		const expectedCategories = ['MANI & PEDI', 'FULL SET & FILL IN'];
+		const expectedCategories = [
+			'MANI & PEDI',
+			'FULL SET & FILL IN',
+			'ADDITIONAL SERVICE',
+		];
 
 		const categoryElements = page.locator('[role="tablist"] span');
 		await expect(categoryElements).toHaveCount(expectedCategories.length);

--- a/e2e/pos-web/src/features/steps.ts
+++ b/e2e/pos-web/src/features/steps.ts
@@ -28,6 +28,17 @@ Then(
 );
 
 Then(
+	'I should not see the employee {string} in the employee list',
+	async ({ page }, employeeName: string) => {
+		const employeeList = page.locator('div.xQueueList');
+
+		await expect(
+			employeeList.getByText(employeeName, { exact: true }),
+		).not.toBeVisible();
+	},
+);
+
+Then(
 	'I should see the {string} screen',
 	async ({ page }, screenName: string) => {
 		const screenTitle = page
@@ -1579,5 +1590,23 @@ Then(
 		});
 		await expect(statusElement).toBeVisible();
 		await expect(statusElement).toContainText(status);
+	},
+);
+
+When(
+	'I click to clock in for employee {string}',
+	async ({ page }, employeeNickname: string) => {
+		const row = page.locator('.MuiDataGrid-row', {
+			has: page.locator(
+				`.MuiDataGrid-cell[data-field="nickName"]:has-text("${employeeNickname}")`,
+			),
+		});
+
+		const clockInIcon = row.locator('[data-testid="ClockInIconIcon"]');
+
+		await expect(row).toBeVisible();
+		await clockInIcon.scrollIntoViewIfNeeded();
+		await expect(clockInIcon).toBeVisible();
+		await clockInIcon.click();
 	},
 );

--- a/e2e/pos-web/src/features/timesheet.feature
+++ b/e2e/pos-web/src/features/timesheet.feature
@@ -1,23 +1,26 @@
-@regression @smoke @skip
+@regression @smoke @slow
 Feature: Timesheet
 
-  Scenario: Clock out
+  Scenario: Clock in and clock out
     Given I am on the HOME page
-    When I clock out the timesheet using PIN "1234"
-    Then I should not see the employee "Owner" in the employee list
+    When I clock in the timesheet with PIN "3493"
+    Then I should see the employee "Tessa" in the employee list
 
-  Scenario: Clock in others
+    When I clock out the timesheet with PIN "3493"
+    Then I should not see the employee "Tessa" in the employee list
+
+  Scenario: Clock in others and clock out
     Given I am on the HOME page
-    When I clock in others the timesheet
+    When I navigate to "Timesheet" on the navigation bar
+    And I select the "Clock In Others" option
     Then I should see a popup dialog with title "Clock In Others"
 
-    When I click to clock in the employee "Nick"
-    And I click on the "Close" button
-    Then I should see the employee "Nick" in the employee list
+    When I wait for the page fully loaded
+    And I click to clock in for employee "Ashley"
+    And I click on the "Close" button in the popup dialog
+    Then I should see the employee "Ashley" in the employee list
 
-  Scenario: Clock in
-    Given I am on the HOME page
-    When I clock in the timesheet with PIN "1234"
-    Then I should see the employee "Owner" in the employee list
+    When I clock out the timesheet with PIN "1310"
+    Then I should not see the employee "Ashley" in the employee list
 
 

--- a/e2e/pos-web/src/steps/x.page.ts
+++ b/e2e/pos-web/src/steps/x.page.ts
@@ -280,17 +280,32 @@ class xPage {
 		// click confirm action button
 		await this.clickOnActionButtonOfOpeningDialog('CONFIRM');
 
-		const successfullyClockedInToast = locators.toast.getByText(
-			'clocked in successfully',
-		); // in case of new session
-		const alreadyClockedInToast = locators.toast.getByText('has clocked in'); // in case there's an existing session
+		if (timesheetAction === 'in') {
+			const successfullyClockedInToast = locators.toast.getByText(
+				'clocked in successfully',
+			); // in case of new session
+			const alreadyClockedInToast = locators.toast.getByText('has clocked in'); // in case there's an existing session
 
-		// expect a toast message indicating the result of the operation
-		await expect(
-			successfullyClockedInToast.or(alreadyClockedInToast),
-		).toBeVisible();
+			// expect a toast message indicating the result of the operation
+			await expect(
+				successfullyClockedInToast.or(alreadyClockedInToast),
+			).toBeVisible();
+		} else if (timesheetAction === 'out') {
+			const successfullyClockedOutToast = locators.toast.getByText(
+				'clocked out successfully',
+			); // in case of clock out
+			const alreadyClockedOutToast =
+				locators.toast.getByText('has not clocked in'); // in case there's no existing session
+
+			// expect a toast message indicating the result of the operation
+			await expect(
+				successfullyClockedOutToast.or(alreadyClockedOutToast),
+			).toBeVisible();
+		}
 
 		// if the dialog is still visible, close it
-		if (await enterPasswordDialog.isVisible()) await this.closeOpeningDialog();
+		if (await enterPasswordDialog.isVisible()) {
+			await this.closeOpeningDialog();
+		}
 	}
 }


### PR DESCRIPTION
## Summary by Sourcery

Update POS-web E2E tests to fully support clock-in and clock-out actions and refine “clock in others” flows

New Features:
- Add step to verify that a given employee is not visible in the employee list
- Introduce step to click the clock-in icon for a specified employee

Enhancements:
- Extend timesheet helper to assert both clock-in and clock-out toast messages based on action
- Standardize dialog close block formatting in x.page.ts

Tests:
- Revise timesheet.feature scenarios by combining clock-in/out flows, updating tags to @slow, adjusting PINs and employee names, and adding explicit navigation and wait steps