### PR TITLE
feat(pos-web): add test cases to verified turn number when updating the ticket

### DIFF
--- a/e2e/pos-web/src/features/appointment.feature
+++ b/e2e/pos-web/src/features/appointment.feature
@@ -227,9 +227,10 @@ Feature: Appointment
     When I select the "Anna" employee from the technician dropdown
     Then I should see the title "Anna"
 
-    When I double click on the time slot at "10:00 AM"
+    When I double click on the time slot at "08:20 AM"
     Then I should see the "Create Appointment" screen
     And I should see the "Manicure" service
+    Then I should see the time "08:20 AM" in my cart
 
     When I add the "Manicure" service to my cart
     Then I should see the service "Manicure" in my cart
@@ -253,7 +254,7 @@ Feature: Appointment
     When I select the "Anna" employee from the technician dropdown
     Then I should see the title "Anna"
 
-    When I select the last booking in the time slot at "10:00 AM"
+    When I select the last booking in the time slot at "08:20 AM"
     And I click on the "Create Ticket" button
     Then I should see the "Ticket View From Appointment" screen
     And I should see the service "Manicure" in my cart
@@ -276,14 +277,14 @@ Feature: Appointment
     Then I should see the title "Any Technician"
     When I select the "Anna" employee from the technician dropdown
     Then I should see the title "Anna"
-    When I select the last booking in the time slot at "10:00 AM"
+    When I select the last booking in the time slot at "08:20 AM"
     And I click on the "Edit" button
 
     Then I should see the "Edit Appointment" screen
     And I should see the service "Manicure" in my cart
     And I should see the employee "Anna" in my cart
     And I should see a new customer "Complete" on ticket
-    And I should see the time "10:00 AM" in my cart
+    And I should see the time "08:20 AM" in my cart
     And I should see the appointment status "Chosen Tech"
     And I should see the appointment status "None"
     And I should see the appointment status "Completed"

--- a/e2e/pos-web/src/features/reopen-ticket.feature
+++ b/e2e/pos-web/src/features/reopen-ticket.feature
@@ -15,9 +15,9 @@ Feature: Reopen tickets
 
     When I click on the total price of "Manicure"
     Then I should see a popup dialog with title "Service: Manicure - $6.00"
-    When I change the price to "11"
+    When I change the price to "11.5"
     And I click on the "Save" button in the popup dialog
-    Then I should see the total price "$11.00" visible
+    Then I should see the total price "$11.50" visible
 
     When I click on the "PAY" button
     Then I should see the text "PAYMENT TICKET" visible
@@ -32,11 +32,11 @@ Feature: Reopen tickets
     When I click on the "Tickets" label in the header
     Then I should be redirected to CLOSED_TICKETS page
 
-    When I search for "11"
+    When I search for "11.5"
     And I wait for the page fully loaded
-    Then I should see the last ticket of payment "$11.00"
+    Then I should see the last ticket of payment "$11.50"
 
-    When I click on the last row for payment "$11.00" to expand details
+    When I click on the last row for payment "$11.50" to expand details
     Then I should see the "Reopen ticket" button visible
 
     When I click on the "Reopen ticket" button

--- a/e2e/pos-web/src/features/steps.ts
+++ b/e2e/pos-web/src/features/steps.ts
@@ -989,6 +989,7 @@ When(
 			has: page.locator('[data-field="customerInfo"]', {
 				hasText: customerInfo,
 			}),
+			hasNot: page.locator('[data-color]:not([data-color="wait"])'),
 		});
 		const firstRow = resultRow.first();
 		await firstRow.scrollIntoViewIfNeeded();
@@ -1424,7 +1425,10 @@ When(
 		await page.waitForTimeout(500);
 
 		// Check if any dialog is visible
-		const dialogVisible = await page.locator('div[role="dialog"]').isVisible();
+		const dialogVisible = await page
+			.locator('div[role="dialog"]')
+			.locator('#draggable-dialog-title')
+			.isVisible();
 
 		if (dialogVisible === true) {
 			// Look for the confirm button
@@ -1504,7 +1508,7 @@ Then(
 Then(
 	'I should see the employees displayed correctly in turn details',
 	async ({ page }) => {
-		const expectedEmployees = ['Addison', 'Anna', 'Emily'];
+		const expectedEmployees = ['Addison', 'Anna', 'Avery', 'Emily', 'Jessica'];
 
 		const employeeElements = page.locator('tbody tr td:first-child div[title]');
 		await expect(employeeElements).toHaveCount(expectedEmployees.length);
@@ -1880,5 +1884,104 @@ Then(
 			.locator('[data-field="ticketTotals"]', { hasText: amount })
 			.first();
 		await expect(totalElement).toBeVisible();
+	},
+);
+
+Then(
+	'I should see the turn number for {string} is 0.0',
+	async ({ page }, name: string) => {
+		const employeeItem = page.locator('li.xEmployeeItem').filter({
+			has: page.locator('.nickname', { hasText: name }),
+		});
+
+		const turnLabel = employeeItem.locator('.MuiChip-label', {
+			hasText: 'Turn: 0.0',
+		});
+		await expect(turnLabel).toBeVisible();
+	},
+);
+
+Then(
+	'I should see the turn number for {string} is 1.0',
+	async ({ page }, name: string) => {
+		const employeeItem = page.locator('li.xEmployeeItem').filter({
+			has: page.getByText(name, { exact: true }),
+		});
+		const turnLabel = employeeItem.getByText('Turn: 1.0', { exact: true });
+		await expect(turnLabel).toBeVisible();
+	},
+);
+
+Then(
+	'I should see the Round 1 for {string}',
+	async ({ page }, name: string) => {
+		const row = page.locator('td').filter({
+			has: page.getByTitle(name),
+		});
+		const roundLabel = row
+			.locator('.MuiChip-root', { hasText: 'Round' })
+			.locator('.MuiChip-label', { hasText: '1' });
+		await expect(roundLabel).toBeVisible();
+	},
+);
+
+Then(
+	'I should see the Round 0 for {string}',
+	async ({ page }, name: string) => {
+		const row = page.locator('td').filter({
+			has: page.getByTitle(name),
+		});
+		const roundLabel = row
+			.locator('.MuiChip-root', { hasText: 'Round' })
+			.locator('.MuiChip-label', { hasText: '0' });
+		await expect(roundLabel).toBeVisible();
+	},
+);
+
+Then(
+	'I should see the Turn 1.00 for {string}',
+	async ({ page }, name: string) => {
+		const row = page.locator('td').filter({
+			has: page.getByTitle(name),
+		});
+		const turnLabel = row
+			.locator('.MuiChip-root', { hasText: 'Turn' })
+			.locator('.MuiChip-label', { hasText: '1.00' });
+		await expect(turnLabel).toBeVisible();
+	},
+);
+
+Then(
+	'I should see the Turn 0.00 for {string}',
+	async ({ page }, name: string) => {
+		const row = page.locator('td').filter({
+			has: page.getByTitle(name),
+		});
+		const turnLabel = row
+			.locator('.MuiChip-root', { hasText: 'Turn' })
+			.locator('.MuiChip-label', { hasText: '0.00' });
+		await expect(turnLabel).toBeVisible();
+	},
+);
+
+Then(
+	'I should see the Auto Turn 1.00 for {string}',
+	async ({ page }, name: string) => {
+		const row = page.locator('tr').filter({
+			has: page.locator(`[title="${name}"]`),
+		});
+		const autoTurn = row.locator('td[turntype="AutoTicket"]', {
+			hasText: '1.00',
+		});
+		await expect(autoTurn).toBeVisible();
+	},
+);
+
+When(
+	'I click on the queue {string} button',
+	async ({ page }, queue: string) => {
+		const queueButton = page.locator('.MuiButtonBase-root', { hasText: queue });
+		await expect(queueButton).toBeVisible();
+		await queueButton.click();
 	},
 );

--- a/e2e/pos-web/src/features/turn-details.feature
+++ b/e2e/pos-web/src/features/turn-details.feature
@@ -13,3 +13,154 @@ Feature: Turn details
 
     When I click on the "Hair" button
     Then I should see the employees displayed correctly in turn details
+
+  Scenario: Turn update or remove when creating or voiding a ticket
+    Given I am on the HOME page
+    When I clock in the timesheet with PIN "5727"
+    And I click on the queue "HAIR" button
+    Then I should see the employee "Jessica" in the employee list
+    And I should see the turn number for "Jessica" is 0.0
+
+    When I select the "Jessica" employee
+    Then I should see the "Ticket View" screen
+    And I should see the "Gel X" service
+    When I add the "Gel X" service to my cart
+    Then I should see my cart showing 1 item added
+
+    When I click on the "PAY" button
+    Then I should see the text "PAYMENT TICKET" visible
+
+    When I click on the element with id "payment"
+    Then I should see a popup dialog with title "Close Ticket"
+    And I should see a popup dialog with content "CHANGE$0.00OK"
+    When I click on the "OK" button in the popup dialog
+    Then I should be redirected to HOME page
+
+    When I click on the queue "Hair" button
+    Then I should see the employee "Jessica" in the employee list
+    And I should see the turn number for "Jessica" is 1.0
+
+    When I navigate to "Turn" on the navigation bar
+    Then I should be redirected to TURN_DETAILS page
+
+    When I wait for the page fully loaded
+    Then I should see the text "Technicians" visible
+    And I should see the text "Hair" visible
+
+    When I click on the "Hair" button
+    Then I should see the Round 1 for "Jessica"
+    And I should see the Turn 1.00 for "Jessica"
+    And I should see the Auto Turn 1.00 for "Jessica"
+
+    When I click on the "Tickets" label in the header
+    Then I should be redirected to CLOSED_TICKETS page
+
+    When I search for "27"
+    And I wait for the page fully loaded
+    Then I should see the last ticket of payment "$27.00"
+
+    When I click on the last row for payment "$27.00" to expand details
+    Then I should see the "Reopen ticket" button visible
+
+    When I click on the "Reopen ticket" button
+    And I wait for the page fully loaded
+    Then I should see the "Ticket View" screen
+    And I should see the user info "Jessica" in the ticket
+
+    When I void the current open ticket with reason "System Test"
+    Then I should be redirected to HOME page
+
+    When I click on the queue "HAIR" button
+    Then I should see the employee "Jessica" in the employee list
+    And I should see the turn number for "Jessica" is 0.0
+
+    When I navigate to "Turn" on the navigation bar
+    Then I should be redirected to TURN_DETAILS page
+
+    When I wait for the page fully loaded
+    Then I should see the text "Technicians" visible
+    And I should see the text "Hair" visible
+
+    When I click on the "Hair" button
+    Then I should see the Round 0 for "Jessica"
+    And I should see the Turn 0.00 for "Jessica"
+
+  Scenario: Turn update when changing technician
+    Given I am on the HOME page
+    When I clock in the timesheet with PIN "3818"
+    Then I should see the employee "Avery" in the employee list
+    And I should see the turn number for "Avery" is 0.0
+
+    When I select the "Avery" employee
+    Then I should see the "Ticket View" screen
+    And I should see the "FULL SET & FILL IN" category
+    When I select the "FULL SET & FILL IN" category
+    And I add the "Fill gel" service to my cart
+    Then I should see my cart showing 1 item added
+
+    When I click on the "PAY" button
+    Then I should see the text "PAYMENT TICKET" visible
+
+    When I click on the element with id "payment"
+    Then I should see a popup dialog with title "Close Ticket"
+    And I should see a popup dialog with content "CHANGE$0.00OK"
+    When I click on the "OK" button in the popup dialog
+    Then I should be redirected to HOME page
+    And I should see the employee "Avery" in the employee list
+    And I should see the turn number for "Avery" is 1.0
+
+    When I click on the "Tickets" label in the header
+    Then I should be redirected to CLOSED_TICKETS page
+
+    When I search for "23.5"
+    And I wait for the page fully loaded
+    Then I should see the last ticket of payment "$23.50"
+
+    When I click on the last row for payment "$23.50" to expand details
+    Then I should see the "Reopen ticket" button visible
+
+    When I click on the "Reopen ticket" button
+    And I wait for the page fully loaded
+    Then I should see the "Ticket View" screen
+    And I should see the user info "Avery" in the ticket
+
+    When I click on the item "Technician" button
+    Then I should see a popup dialog with title "TECHNICIAN MULTIPLE"
+    When I select the "Fill gel" service in the dialog
+    And I select the "Zoey" employee in the dialog
+    And I click on the "Apply" button in the dialog
+    Then I should see the "Zoey" employee in my cart
+
+    When I click on the "PAY" button
+    And I click on the "CLOSE TICKET" button
+    Then I should be redirected to HOME page
+    And I should see the turn number for "Avery" is 0.0
+    And I should see the turn number for "Zoey" is 1.0
+
+    When I navigate to "Turn" on the navigation bar
+    Then I should be redirected to TURN_DETAILS page
+    And I should see the text "Technicians" visible
+    And I should see the text "All" visible
+    And I should see the Round 1 for "Zoey"
+    And I should see the Turn 1.00 for "Zoey"
+    And I should see the Auto Turn 1.00 for "Zoey"
+    And I should see the Round 0 for "Avery"
+    And I should see the Turn 0.00 for "Avery"
+
+    When I click on the "Tickets" label in the header
+    Then I should be redirected to CLOSED_TICKETS page
+
+    When I search for "23.5"
+    And I wait for the page fully loaded
+    Then I should see the last ticket of payment "$23.50"
+
+    When I click on the last row for payment "$23.50" to expand details
+    Then I should see the "Reopen ticket" button visible
+
+    When I click on the "Reopen ticket" button
+    And I wait for the page fully loaded
+    Then I should see the "Ticket View" screen
+    And I should see the user info "Zoey" in the ticket
+
+    When I void the current open ticket with reason "System Test"
+    Then I should be redirected to HOME page

--- a/e2e/pos-web/src/steps/x.page.ts
+++ b/e2e/pos-web/src/steps/x.page.ts
@@ -227,7 +227,7 @@ class xPage {
 		const dialog = locators.dialog();
 		const dialogContent = locators.dialogContent(dialog);
 
-		await dialogContent.getByText(text, { exact: true }).click();
+		await dialogContent.getByText(text, { exact: true }).last().click();
 	}
 
 	/**


### PR DESCRIPTION
## Summary by Sourcery

Improve E2E test coverage around technician turn tracking by adding scenarios and step definitions to assert turn numbers, rounds, and auto-turn values across ticket creation, closure, reopening, voiding, and technician changes.

New Features:
- Add end-to-end scenarios for verifying turn number updates when creating, closing, reopening, and voiding tickets

Enhancements:
- Extend turn-details feature with checks for start/end turn counts, round labels, and auto-turn values
- Adjust appointment scenarios to use 08:20 AM slots and verify time in cart
- Update reopen-ticket feature to use a 11.5 price change and expected value

Tests:
- Implement new step definitions for asserting turn numbers, rounds, and auto-turn labels
- Refine dialog visibility locator and add a reusable step for clicking queue buttons

Chores:
- Extend expected employees in turn-details steps
- Refine page helper to click the last matching dialog option