### PR TITLE
feat(pos-web): add test case to verify the loyalty point on the receipt UI

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -22,9 +22,6 @@
 			}
 		}
 	},
-	"organizeImports": {
-		"enabled": true
-	},
 	"javascript": {
 		"formatter": {
 			"quoteStyle": "single",

--- a/e2e/pos-web/src/features/check-in.feature
+++ b/e2e/pos-web/src/features/check-in.feature
@@ -42,7 +42,8 @@ Feature: Check In
     And I should see the service "Combo 1" in the waiting list
     And I should see the technician "Any Technician" in the waiting list
 
-    When I click on the first row for customer "Check-in" to expand details
+    When I wait for the page fully loaded
+    And I click on the first row for customer "Check-in" to expand details
     Then I should see the "Create Ticket" button visible
 
     When I click on the "Create Ticket" button
@@ -160,7 +161,8 @@ Feature: Check In
     Then I should see the customer "Waiting" in the waiting list
     And I should see the service "MANI & PEDI" in the waiting list
 
-    When I click on the first row for customer "Waiting" to expand details
+    When I wait for the page fully loaded
+    And I click on the first row for customer "Waiting" to expand details
     Then I should see the "Create Ticket" button visible
 
     When I click on the "Create Ticket" button
@@ -170,7 +172,8 @@ Feature: Check In
     And I should see the service hint
     And I should see the hint details "MANI & PEDI (Next Available)"
 
-    When I add the "Acrylic removal" service to my cart
+    When I wait for the page fully loaded
+    And I add the "Acrylic removal" service to my cart
     Then I should see my cart showing 1 item added
     And I should see the "Anna" employee in my cart
 
@@ -223,7 +226,8 @@ Feature: Check In
     And I should see the service "Gel X" in the waiting list
     And I should see the technician "Addison" in the waiting list
 
-    When I click on the first row for customer "Editing" to expand details
+    When I wait for the page fully loaded
+    And I click on the first row for customer "Editing" to expand details
     Then I should see the "Edit" button visible
 
     When I click on the "Edit" button
@@ -247,7 +251,8 @@ Feature: Check In
     And I should see the service "Gel X" in the waiting list
     And I should see the service "Cut cuticle" in the waiting list
 
-    When I click on the first row for customer "Editing" to expand details
+    When I wait for the page fully loaded
+    And I click on the first row for customer "Editing" to expand details
     Then I should see the "Create Ticket" button visible
 
     When I click on the "Create Ticket" button
@@ -303,7 +308,8 @@ Feature: Check In
     Then I should see the customer "Duration" in the waiting list
     And I should see the service "FULL SET & FILL IN" in the waiting list
 
-    When I click on the first row for customer "Duration" to expand details
+    When I wait for the page fully loaded
+    And I click on the first row for customer "Duration" to expand details
     Then I should see the "Create Ticket" button visible
 
     When I click on the "Make Appt" button
@@ -319,7 +325,8 @@ Feature: Check In
     And I should see the service hint
     And I should see the hint details "FULL SET & FILL IN (Next Available)"
 
-    When I add the "Acrylic removal" service to my cart
+    When I wait for the page fully loaded
+    And I add the "Acrylic removal" service to my cart
     Then I should see my cart showing 1 item added
     And I should see the "Anna" employee in my cart
 
@@ -426,7 +433,8 @@ Feature: Check In
     And I should see the user info "Victoria" in the ticket
     And I should see the "Pedicure" service
 
-    When I add the "Pedicure" service to my cart
+    When I wait for the page fully loaded
+    And I add the "Pedicure" service to my cart
     Then I should see the service "Pedicure" in my cart
 
     When I click on the item "Technician" button
@@ -440,6 +448,73 @@ Feature: Check In
     Then I should not see the service "Acrylic removal" in my cart
     And I should see the user info "Anna" in the ticket
 
+    When I click on the "PAY" button
+    Then I should see the text "PAYMENT TICKET" visible
+    And I should see the text "PAYMENT HISTORY" visible
+    And I should see the button with id "payment" visible
+
+    When I click on the element with id "payment"
+    Then I should see a popup dialog with title "Close Ticket"
+    And I should see a popup dialog with content "CHANGE$0.00OK"
+    When I click on the "OK" button in the popup dialog
+    Then I should be redirected to HOME page
+
+  Scenario: Recreate a waiting after voiding ticket
+    Given I am on the HOME page
+    When I wait for the page fully loaded
+    And I click on the "Check In" label in the header
+    Then I should be redirected to WAITING_LIST page
+
+    When I click on the "Add Customer" button in the waiting page
+    Then I should see the text "Create Waiting" visible
+
+    When I click on the Select customer
+    And I click on the "Click Here To Add Customers" button
+    Then I should see a popup dialog with title "Create New Customer"
+    And I should see the loyalty program "2 Points = $1" visible
+
+    When I fill the new customer name "Recreate"
+    And I fill the new customer phone
+    And I click on the "SAVE" button in the create new customer dialog
+    Then I should see a new customer "Recreate" on ticket
+
+    When I select the "FULL SET & FILL IN" category
+    When I add the "Full set" service to my cart
+    Then I should see a popup dialog with title "Pick Technician"
+    When I click on the "Anna" text inside the content section of the opening dialog
+    Then I should see the service "Full set" in my cart
+    And I should see the duration "25 mins" in my cart
+
+    When I click on the "SAVE" button
+    And I wait for the page fully loaded
+    Then I should be redirected to WAITING_LIST page
+
+    When I wait for the page fully loaded
+    Then I should see the customer "Recreate" in the waiting list
+    And I should see the service "Full set" in the waiting list
+    And I should see the technician "Anna" in the waiting list
+
+    When I wait for the page fully loaded
+    And I click on the first row for customer "Recreate" to expand details
+    Then I should see the "Create Ticket" button visible
+
+    When I click on the "Create Ticket" button
+    And I wait for the page fully loaded
+    Then I should see the "Ticket View" screen
+    And I should see the "Manicure" service
+    And I should see the user info "Anna" in the ticket
+    When I wait for the page fully loaded
+    And I void the current open ticket with reason "Mistake"
+    Then I should be redirected to HOME page
+
+    When I click on the "Check In" label in the header
+    Then I should be redirected to WAITING_LIST page
+    When I wait for the page fully loaded
+    And I click on the first row for customer "Recreate" to expand details
+    Then I should see the "Create Ticket" button visible
+
+    When I click on the "Create Ticket" button
+    Then I should see the "Ticket View" screen
     When I click on the "PAY" button
     Then I should see the text "PAYMENT TICKET" visible
     And I should see the text "PAYMENT HISTORY" visible

--- a/e2e/pos-web/src/features/steps.ts
+++ b/e2e/pos-web/src/features/steps.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
-import { createBdd } from 'playwright-bdd';
 import type { DataTable } from 'playwright-bdd';
+import { createBdd } from 'playwright-bdd';
 
 import { constants } from '#const';
 import type { PageId } from '#types';
@@ -1985,3 +1985,278 @@ When(
 		await queueButton.click();
 	},
 );
+
+When(
+	'I double click on the first turn detail for {string}',
+	async ({ page }, name: string) => {
+		const row = page.locator('tr').filter({
+			has: page.locator(`[title="${name}"]`),
+		});
+		const firstTurnDetail = row.locator('td').nth(1);
+		await expect(firstTurnDetail).toBeVisible();
+		await firstTurnDetail.dblclick();
+	},
+);
+
+Then(
+	'I should see the Auto Turn -1.00 for {string}',
+	async ({ page }, name: string) => {
+		const row = page.locator('tr').filter({
+			has: page.locator(`[title="${name}"]`),
+		});
+		const manualTurn = row.locator('td[turntype="Manual"]', {
+			hasText: /-1\.00.*M/,
+		});
+		await expect(manualTurn).toBeVisible();
+	},
+);
+
+Then(
+	'I should see the Auto Turn 20.00 for {string}',
+	async ({ page }, name: string) => {
+		const row = page.locator('tr').filter({
+			has: page.locator(`[title="${name}"]`),
+		});
+		const manualTurn = row.locator('td[turntype="Manual"]', {
+			hasText: /20\.00.*M/,
+		});
+		await expect(manualTurn).toBeVisible();
+	},
+);
+
+Then(
+	'I should see the employee {string} listed first in the employee list',
+	async ({ page }, employeeName: string) => {
+		const firstEmployee = page
+			.locator('div.xQueueList li.xEmployeeItem')
+			.first();
+
+		await expect(firstEmployee).toContainText(employeeName);
+	},
+);
+
+Then(
+	'I should see the employee {string} listed last in the employee list',
+	async ({ page }, employeeName: string) => {
+		const lastEmployee = page.locator('div.xQueueList li.xEmployeeItem').last();
+
+		await expect(lastEmployee).toContainText(employeeName);
+	},
+);
+
+Then(
+	'I should see the Turn -1.00 for {string}',
+	async ({ page }, name: string) => {
+		const row = page.locator('td').filter({
+			has: page.getByTitle(name),
+		});
+		const turnLabel = row
+			.locator('.MuiChip-root', { hasText: 'Turn' })
+			.locator('.MuiChip-label', { hasText: '-1.00' });
+		await expect(turnLabel).toBeVisible();
+	},
+);
+
+Then(
+	'I should see the Turn 20.00 for {string}',
+	async ({ page }, name: string) => {
+		const row = page.locator('td').filter({
+			has: page.getByTitle(name),
+		});
+		const turnLabel = row
+			.locator('.MuiChip-root', { hasText: 'Turn' })
+			.locator('.MuiChip-label', { hasText: '20.00' });
+		await expect(turnLabel).toBeVisible();
+	},
+);
+
+Then('I should see the store logo on the receipt', async ({ page }) => {
+	await expect(page.locator('img[alt="BLANC"]')).toBeVisible();
+});
+
+Then(
+	'I should see the business info {string} on the receipt',
+	async ({ page }, businessInfo: string) => {
+		const businessInfoLocator = page.locator('.flex-3').first();
+
+		const actualText = await businessInfoLocator.innerText();
+		const normalizedActual = actualText.replace(/\s+/g, ' ').trim();
+		const normalizedExpected = businessInfo.replace(/\s+/g, ' ').trim();
+
+		expect(normalizedActual).toBe(normalizedExpected);
+	},
+);
+
+Then('I should see the date is today on the receipt', async ({ page }) => {
+	const dateCell = page.locator(
+		'table.mt-1 td.left-column:has-text("Date") + td',
+	);
+	const receiptDateText = await dateCell.innerText();
+	const today = new Date();
+
+	const formattedToday = today
+		.toLocaleDateString('en-US', {
+			year: 'numeric',
+			month: '2-digit',
+			day: '2-digit',
+		})
+		.replace(/\//g, '/'); // e.g., 06/18/2025
+
+	expect(receiptDateText).toContain(formattedToday);
+});
+
+Then(
+	'I should see the customer name {string} on the receipt',
+	async ({ page }, customerName: string) => {
+		const customerCell = page.locator(
+			'table.mt-1 td.left-column:has-text("Customer") + td',
+		);
+		const receiptCustomerText = await customerCell.innerText();
+		expect(receiptCustomerText).toContain(customerName);
+	},
+);
+
+Then(
+	'I should see the point {string} on the receipt',
+	async ({ page }, point: string) => {
+		const pointCell = page.locator(
+			'table.mt-1 td.left-column:has-text("Point") + td',
+		);
+		const actualPoint = await pointCell.innerText();
+		expect(actualPoint.trim()).toBe(point);
+	},
+);
+
+Then(
+	'I should see the service quantity {string} on the receipt',
+	async ({ page }, qty: string) => {
+		const qtyCell = page.locator('.ticket-item .flex-05', { hasText: qty });
+		await expect(qtyCell).toBeVisible();
+	},
+);
+
+Then(
+	'I should see the service name {string} on the receipt',
+	async ({ page }, item: string) => {
+		const serviceName = page.locator('.ticket-item .flex-3', { hasText: item });
+		await expect(serviceName).toBeVisible();
+	},
+);
+
+Then(
+	'I should see the technician name {string} on the receipt',
+	async ({ page }, name: string) => {
+		const technicianName = page.locator('.ticket-item #userInfo', {
+			hasText: name,
+		});
+		await expect(technicianName).toBeVisible();
+	},
+);
+
+Then(
+	'I should see the service price {string} on the receipt',
+	async ({ page }, price: string) => {
+		const priceCell = page.locator('.ticket-item .align-right', {
+			hasText: price,
+		});
+		await expect(priceCell).toBeVisible();
+	},
+);
+
+Then(
+	'I should see the TIP amount {string} on the receipt',
+	async ({ page }, tip: string) => {
+		const tipCell = page.locator('tr:has-text("TIP") .align-right', {
+			hasText: tip,
+		});
+		await expect(tipCell).toBeVisible();
+	},
+);
+
+Then(
+	'I should see the SUBTOTAL {string} on the receipt',
+	async ({ page }, subtotal: string) => {
+		const subtotalCell = page.locator('tr:has-text("SUBTOTAL") .align-right', {
+			hasText: subtotal,
+		});
+		await expect(subtotalCell).toBeVisible();
+	},
+);
+
+Then(
+	'I should see the TAX {string} on the receipt',
+	async ({ page }, tax: string) => {
+		const taxCell = page.locator('tr:has-text("TAX") .align-right', {
+			hasText: tax,
+		});
+		await expect(taxCell).toBeVisible();
+	},
+);
+
+Then(
+	'I should see the TOTAL {string} on the receipt',
+	async ({ page }, total: string) => {
+		const totalCell = page
+			.locator('tr:has-text("TOTAL") .align-right', {
+				hasText: total,
+			})
+			.last();
+		await expect(totalCell).toBeVisible();
+	},
+);
+
+Then(
+	'I should see the CHANGE amount {string} on the receipt',
+	async ({ page }, change: string) => {
+		const changeCell = page.locator('tr:has-text("CHANGE") .align-right', {
+			hasText: change,
+		});
+		await expect(changeCell).toBeVisible();
+	},
+);
+
+Then(
+	'I should see the payment label {string} on the receipt',
+	async ({ page }, label: string) => {
+		const paymentLabel = page.locator('.align-center.mt-1', { hasText: label });
+		await expect(paymentLabel).toBeVisible();
+	},
+);
+
+Then(
+	'I should see the payment method {string} on the receipt',
+	async ({ page }, method: string) => {
+		const paymentMethod = page.locator('td', { hasText: method });
+		await expect(paymentMethod).toBeVisible();
+	},
+);
+
+Then(
+	'I should see the cash payment amount {string} on the receipt',
+	async ({ page }, amount: string) => {
+		const paymentAmount = page.locator('tr:has-text("Cash") .align-right', {
+			hasText: amount,
+		});
+		await expect(paymentAmount).toBeVisible();
+	},
+);
+
+Then(
+	'I should see the message {string} on the receipt',
+	async ({ page }, msg: string) => {
+		const message = page.locator('.align-center', { hasText: msg });
+		await expect(message).toBeVisible();
+	},
+);
+
+Then(
+	'I should see the tip guide {string} on the receipt',
+	async ({ page }, msg: string) => {
+		const message = page.locator('td', { hasText: msg });
+		await expect(message).toBeVisible();
+	},
+);
+
+Then('I should see the QR code on the receipt', async ({ page }) => {
+	await expect(page.locator('.qr img')).toBeVisible();
+});

--- a/e2e/pos-web/src/features/tickets.feature
+++ b/e2e/pos-web/src/features/tickets.feature
@@ -679,7 +679,7 @@ Feature: Reopen tickets
     And I should see the business info "BLANC NAILS 1032 YONKERS AVE Yonkers, NY 10704 (707) 707-1122" on the receipt
 
     Then I should see the date is today on the receipt
-    And I should see the customer name "Loyaly" on the receipt
+    And I should see the customer name "Loyalty" on the receipt
     And I should see the point "70 = $0.70" on the receipt
 
     Then I should see the service quantity "1" on the receipt
@@ -695,7 +695,7 @@ Feature: Reopen tickets
     Then I should see the CHANGE amount "$0.00" on the receipt
 
     Then I should see the payment label "PAYMENT DETAILS" on the receipt
-    And I should see the payment method "Cash - $50.00" on the receipt
+    And I should see the payment method "Cash - $35.50" on the receipt
     And I should see the cash payment amount "$35.50" on the receipt
 
     Then I should see the message "Come back again soon..." on the receipt

--- a/e2e/pos-web/src/features/tickets.feature
+++ b/e2e/pos-web/src/features/tickets.feature
@@ -633,3 +633,76 @@ Feature: Reopen tickets
     And I wait for the page fully loaded
     Then I should see the title contain "Jimmy" visible
     And I should see the text "No rows" visible
+
+  Scenario: View the loyalty point on Receipt
+    Given I am on the HOME page
+    When I clock in the timesheet with PIN "2883"
+    Then I should see the employee "Gabriella" in the employee list
+    When I select the "Gabriella" employee
+    And I add the "Manicure" service to my cart
+    Then I should see my cart showing 1 item added
+
+    When I click on the total price of "Manicure"
+    Then I should see a popup dialog with title "Service: Manicure - $6.00"
+    When I change the price to "35.5"
+    And I click on the "Save" button in the popup dialog
+    Then I should see the total price "$35.50" visible
+
+    When I click on the Select customer
+    And I click on the "Click Here To Add Customers" button
+    Then I should see a popup dialog with title "Create New Customer"
+    And I should see the loyalty program "2 Points = $1" visible
+
+    When I fill the new customer name "Loyalty"
+    And I fill the new customer phone
+    And I click on the "SAVE" button in the create new customer dialog
+    Then I should see a new customer "Loyalty" on ticket
+
+    When I click on the "PAY" button
+    Then I should see the text "PAYMENT TICKET" visible
+
+    When I click on the element with id "payment"
+    Then I should see a popup dialog with title "Close Ticket"
+    And I should see a popup dialog with content "CHANGE$0.00OK"
+    When I click on the "OK" button in the popup dialog
+    Then I should be redirected to HOME page
+
+    When I click on the "Tickets" label in the header
+    Then I should be redirected to CLOSED_TICKETS page
+
+    When I search for "35.5"
+    And I wait for the page fully loaded
+    Then I should see the last ticket of payment "$35.50"
+
+    When I click on the last row for payment "$35.50" to expand details
+    Then I should see the store logo on the receipt
+    And I should see the business info "BLANC NAILS 1032 YONKERS AVE Yonkers, NY 10704 (707) 707-1122" on the receipt
+
+    Then I should see the date is today on the receipt
+    And I should see the customer name "Loyaly" on the receipt
+    And I should see the point "70 = $0.70" on the receipt
+
+    Then I should see the service quantity "1" on the receipt
+    And I should see the service name "Manicure" on the receipt
+    And I should see the technician name "Gabriella" on the receipt
+    And I should see the service price "$35.50" on the receipt
+
+    Then I should see the TIP amount "$0.00" on the receipt
+    And I should see the SUBTOTAL "$35.50" on the receipt
+    And I should see the TAX "$0.00" on the receipt
+    And I should see the TOTAL "$35.50" on the receipt
+
+    Then I should see the CHANGE amount "$0.00" on the receipt
+
+    Then I should see the payment label "PAYMENT DETAILS" on the receipt
+    And I should see the payment method "Cash - $50.00" on the receipt
+    And I should see the cash payment amount "$35.50" on the receipt
+
+    Then I should see the message "Come back again soon..." on the receipt
+    And I should see the message "Thank you <3" on the receipt
+
+    Then I should see the tip guide "10% TIP = $3.55" on the receipt
+    And I should see the tip guide "15% TIP = $5.32" on the receipt
+    And I should see the tip guide "20% TIP = $7.10" on the receipt
+
+    Then I should see the QR code on the receipt

--- a/e2e/pos-web/src/features/turn-details.feature
+++ b/e2e/pos-web/src/features/turn-details.feature
@@ -164,3 +164,89 @@ Feature: Turn details
 
     When I void the current open ticket with reason "System Test"
     Then I should be redirected to HOME page
+
+  Scenario: Manually adding decrease a turn reorders the employee queue
+    Given I am on the HOME page
+    When I navigate to "Turn" on the navigation bar
+    Then I should be redirected to TURN_DETAILS page
+
+    When I wait for the page fully loaded
+    Then I should see the text "Technicians" visible
+    And I should see the text "All" visible
+    When I click on the "Nails" button
+    Then I should see the Round 0 for "Leah"
+    And I should see the Turn 0.00 for "Leah"
+
+    When I double click on the first turn detail for "Leah"
+    Then I should see a popup dialog containing the title "Nails"
+    And I should see a popup dialog with content "Technician: Leah"
+
+    When I enter the amount "1"
+    And I click on the "DECREASE" button in the popup dialog
+
+    When I wait for the page fully loaded
+    Then I should see the Auto Turn -1.00 for "Leah"
+
+    When I back to HOME page
+    Then I should see the employee "Leah" listed first in the employee list
+
+    When I navigate to "Turn" on the navigation bar
+    Then I should be redirected to TURN_DETAILS page
+
+    When I wait for the page fully loaded
+    Then I should see the text "Technicians" visible
+    And I should see the text "All" visible
+    When I click on the "Nails" button
+    Then I should see the Round 1 for "Leah"
+    And I should see the Turn -1.00 for "Leah"
+
+    When I double click on the first turn detail for "Leah"
+    Then I should see a popup dialog containing the title "Nails"
+    When I click on the "DELETE TURN" button in the popup dialog
+
+    When I wait for the page fully loaded
+    Then I should see the Turn 0.00 for "Leah"
+    And I should see the Round 0 for "Leah"
+
+  Scenario: Manually adding increase a turn reorders the employee queue
+    Given I am on the HOME page
+    When I navigate to "Turn" on the navigation bar
+    Then I should be redirected to TURN_DETAILS page
+
+    When I wait for the page fully loaded
+    Then I should see the text "Technicians" visible
+    And I should see the text "All" visible
+    When I click on the "Nails" button
+    Then I should see the Round 0 for "Amelia"
+    And I should see the Turn 0.00 for "Amelia"
+
+    When I double click on the first turn detail for "Amelia"
+    Then I should see a popup dialog containing the title "Nails"
+    And I should see a popup dialog with content "Technician: Amelia"
+
+    When I enter the amount "20"
+    And I click on the "INCREASE" button in the popup dialog
+
+    When I wait for the page fully loaded
+    Then I should see the Auto Turn 20.00 for "Amelia"
+
+    When I back to HOME page
+    Then I should see the employee "Amelia" listed last in the employee list
+
+    When I navigate to "Turn" on the navigation bar
+    Then I should be redirected to TURN_DETAILS page
+
+    When I wait for the page fully loaded
+    Then I should see the text "Technicians" visible
+    And I should see the text "All" visible
+    When I click on the "Nails" button
+    Then I should see the Round 1 for "Amelia"
+    And I should see the Turn 20.00 for "Amelia"
+
+    When I double click on the first turn detail for "Amelia"
+    Then I should see a popup dialog containing the title "Nails"
+    When I click on the "DELETE TURN" button in the popup dialog
+
+    When I wait for the page fully loaded
+    Then I should see the Turn 0.00 for "Amelia"
+    And I should see the Round 0 for "Amelia"


### PR DESCRIPTION
## Summary by Sourcery

Add comprehensive E2E tests for loyalty point display on receipts, turn detail adjustments with queue reorder, and waiting list recreation post-void, while stabilizing check-in flows with page-load waits and renaming a feature file.

New Features:
- Add E2E scenario to verify loyalty points and detailed receipt UI for closed tickets
- Add E2E scenarios for manual turn adjustments and automatic queue reordering in turn details
- Add E2E scenario for recreating a waiting entry after voiding a ticket in the check-in flow

Enhancements:
- Introduce a 'wait for the page fully loaded' step across multiple check-in feature scenarios

Tests:
- Add step definitions to validate store logo, business info, date, customer, point balance, service details, payment breakdown, tip guides, and QR code on receipts
- Extend turn-detail steps to handle double-click interactions, auto-increment/decrement actions, and verify reordered employee listings

Chores:
- Rename reopen-ticket.feature to tickets.feature