### PR TITLE
fix(pos-web): add clock out step for each TC

### DIFF
--- a/e2e/galaxy-pink-web/src/features/create-tickets.feature
+++ b/e2e/galaxy-pink-web/src/features/create-tickets.feature
@@ -595,6 +595,8 @@ Feature: Create tickets
     Then I should not see the employee "Eira" in the ticket list
     And I should not see the employee "Maya" in the ticket list
 
+    When I clock out the timesheet with PIN "4857"
+
   Scenario: Void the item when creating a ticket
     Given I am on the HOME page
     When I clock in the timesheet with PIN "0404"

--- a/e2e/pos-web-offline/src/features/create-tickets.feature
+++ b/e2e/pos-web-offline/src/features/create-tickets.feature
@@ -189,7 +189,7 @@ Feature: Create tickets
 @fix
   Scenario: Verify that the balance is updated correctly when paying with a gift card
     Given I am on the HOME page
-    When I clock in the timesheet with PIN "0404"
+    When I clock in the timesheet with PIN "0004"
     Then I should see the employee "Emma" in the employee list
     When I select the "Emma" employee
     Then I should see the "Ticket View" screen

--- a/e2e/pos-web/src/features/close-out.feature
+++ b/e2e/pos-web/src/features/close-out.feature
@@ -77,6 +77,7 @@ Feature: Close Out report
     # Then I should not see the employee "Elena" in the ticket list
 
     When I delete ticket after void it with payment amount "231.70"
+    And I clock out the timesheet with PIN "7518"
 
   Scenario: Technician report summary display correctly
     Given I am on the HOME page
@@ -132,3 +133,4 @@ Feature: Close Out report
     # And I should not see the employee "Gemma" in the ticket list
 
     When I delete ticket after void it with payment amount "232.70"
+    And I clock out the timesheet with PIN "7298"

--- a/e2e/pos-web/src/features/create-tickets.feature
+++ b/e2e/pos-web/src/features/create-tickets.feature
@@ -103,6 +103,8 @@ Feature: Create tickets
     And I should see the first type "Issuance" in the loyalty detail list
     And I should see the first amount "0" in the gift card detail list
 
+    When I clock out the timesheet with PIN "8102"
+
   Scenario: Create a new customer on the fly
     Given I am on the HOME page
     When I clock in the timesheet with PIN "0917"
@@ -160,6 +162,8 @@ Feature: Create tickets
     When I click on the "OK" button in the popup dialog
     Then I should be redirected to HOME page
 
+    When I clock out the timesheet with PIN "2860"
+
   Scenario: Create a ticket, add Tip and pay with Credit card
     Given I am on the HOME page
     When I clock in the timesheet with PIN "0101"
@@ -187,9 +191,11 @@ Feature: Create tickets
     And I click on the element with id "payment"
     Then I should be redirected to HOME page
 
+    When I clock out the timesheet with PIN "0101"
+
   Scenario: Verify that the balance is updated correctly when paying with a gift card
     Given I am on the HOME page
-    When I clock in the timesheet with PIN "0404"
+    When I clock in the timesheet with PIN "0004"
     Then I should see the employee "Emma" in the employee list
     When I select the "Emma" employee
     Then I should see the "Ticket View" screen
@@ -215,6 +221,8 @@ Feature: Create tickets
     And I should see the first type "Redeem" in the gift card detail list
     And I should see the first amount "($6.00)" in the gift card detail list
 
+    When I clock out the timesheet with PIN "0004"
+
   Scenario: Create a ticket and pay with Zelle type
     Given I am on the HOME page
     When I clock in the timesheet with PIN "0505"
@@ -233,6 +241,8 @@ Feature: Create tickets
     When I select the "Zelle" payment type
     And I click on the element with id "payment"
     Then I should be redirected to HOME page
+
+    When I clock out the timesheet with PIN "0505"
 
   Scenario: Split tip by Percent on ticket after paying by Credit card
     Given I am on the HOME page
@@ -276,6 +286,8 @@ Feature: Create tickets
     When I click on the "CLOSE TICKET" button
     Then I should be redirected to HOME page
 
+    When I clock out the timesheet with PIN "0202"
+
   Scenario: Create a ticket and pay with Cash change
     Given I am on the HOME page
     When I clock in the timesheet with PIN "9076"
@@ -298,6 +310,8 @@ Feature: Create tickets
     And I should see a popup dialog with content "CHANGE$60.00OK"
     When I click on the "OK" button in the popup dialog
     Then I should be redirected to HOME page
+
+    When I clock out the timesheet with PIN "9076"
 
   Scenario: Make multiple payments using Gift Card and Credit
     Given I am on the HOME page
@@ -331,6 +345,8 @@ Feature: Create tickets
     And I click on the element with id "payment"
     Then I should be redirected to HOME page
 
+    When I clock out the timesheet with PIN "1219"
+
   Scenario: Change price and add note for service in ticket
     Given I am on the HOME page
     When I clock in the timesheet with PIN "1828"
@@ -360,6 +376,8 @@ Feature: Create tickets
     And I should see a popup dialog with content "CHANGE$0.00OK"
     When I click on the "OK" button in the popup dialog
     Then I should be redirected to HOME page
+
+    When I clock out the timesheet with PIN "1828"
 
   Scenario: Add the Open Discount amount for Discount item
     Given I am on the HOME page
@@ -399,6 +417,8 @@ Feature: Create tickets
     When I click on the "OK" button in the popup dialog
     Then I should be redirected to HOME page
 
+    When I clock out the timesheet with PIN "8623"
+
   Scenario: Add the Open Discount percent for Discount ticket
     Given I am on the HOME page
     When I clock in the timesheet with PIN "9962"
@@ -431,6 +451,8 @@ Feature: Create tickets
     And I should see a popup dialog with content "CHANGE$0.00OK"
     When I click on the "OK" button in the popup dialog
     Then I should be redirected to HOME page
+
+    When I clock out the timesheet with PIN "9962"
 
   Scenario: Sell a Gift Card add-on amount
     Given I am on the HOME page
@@ -469,6 +491,8 @@ Feature: Create tickets
     And I should see the first type "ActivateAddOn" in the gift card detail list
     And I should see the first amount "$100.00" in the gift card detail list
 
+    When I clock out the timesheet with PIN "1010"
+
   Scenario: Sell a Gift Card rewrite amount
     Given I am on the HOME page
     When I clock in the timesheet with PIN "5362"
@@ -506,6 +530,8 @@ Feature: Create tickets
     And I should see the first type "Overwrite" in the gift card detail list
     And I should see the first amount "$100.00" in the gift card detail list
 
+    When I clock out the timesheet with PIN "5362"
+
   Scenario: Remove tax in ticket
     Given I am on the HOME page
     When I clock in the timesheet with PIN "6993"
@@ -529,6 +555,8 @@ Feature: Create tickets
     And I should see a popup dialog with content "CHANGE$0.00OK"
     When I click on the "OK" button in the popup dialog
     Then I should be redirected to HOME page
+
+    When I clock out the timesheet with PIN "6993"
 
   Scenario: Void an empty ticket
     Given I am on the HOME page
@@ -621,6 +649,8 @@ Feature: Create tickets
     Then I should not see the employee "Eira" in the ticket list
     And I should not see the employee "Maya" in the ticket list
 
+    When I clock out the timesheet with PIN "4857"
+
   Scenario: Void the item when creating a ticket
     Given I am on the HOME page
     When I clock in the timesheet with PIN "0404"
@@ -661,6 +691,8 @@ Feature: Create tickets
     When I click on the "OK" button in the popup dialog
     Then I should be redirected to HOME page
 
+    When I clock out the timesheet with PIN "0404"
+
   Scenario: Change Technician for Service package
     Given I am on the HOME page
     When I clock in the timesheet with PIN "6769"
@@ -694,6 +726,8 @@ Feature: Create tickets
     And I should see a popup dialog with content "CHANGE$0.00OK"
     When I click on the "OK" button in the popup dialog
     Then I should be redirected to HOME page
+
+    When I clock out the timesheet with PIN "6769"
 
   Scenario: Remove payment history and choose another one
     Given I am on the HOME page
@@ -777,6 +811,8 @@ Feature: Create tickets
     When I click on the "OK" button in the popup dialog
     Then I should be redirected to HOME page
 
+    When I clock out the timesheet with PIN "2406"
+
   Scenario: Select Tech to split tip by percent
     Given I am on the HOME page
     When I clock in the timesheet with PIN "3030"
@@ -829,6 +865,8 @@ Feature: Create tickets
     When I click on the "CLOSE TICKET" button
     Then I should be redirected to HOME page
 
+    When I clock out the timesheet with PIN "3030"
+
   Scenario: Cannot pay more than the Gift card Balance
     Given I am on the HOME page
     When I clock in the timesheet with PIN "4040"
@@ -873,6 +911,7 @@ Feature: Create tickets
     # And I should not see the employee "Aubrey" in the ticket list
 
     When I delete ticket after void it with payment amount "35.7"
+    And I clock out the timesheet with PIN "4040"
 
   Scenario: Select service to change technician
     Given I am on the HOME page
@@ -900,6 +939,8 @@ Feature: Create tickets
     And I should see a popup dialog with content "CHANGE$0.00OK"
     When I click on the "OK" button in the popup dialog
     Then I should be redirected to HOME page
+
+    When I clock in the timesheet with PIN "8226"
 
   Scenario: Add the Discount ticket while paying
     Given I am on the HOME page
@@ -929,6 +970,8 @@ Feature: Create tickets
     And I should see a popup dialog with content "CHANGE$0.00OK"
     When I click on the "OK" button in the popup dialog
     Then I should be redirected to HOME page
+
+    When I clock out the timesheet with PIN "6512"
 
   Scenario: Show earning today
     Given I am on the HOME page
@@ -980,6 +1023,7 @@ Feature: Create tickets
     # And I should not see the employee "Paige" in the ticket list
 
     When I delete ticket after void it with payment amount "55.00"
+    And I clock out the timesheet with PIN "0074"
 
   Scenario: No cash discount is charged when selling GC
     Given I am on the HOME page
@@ -1008,6 +1052,8 @@ Feature: Create tickets
     And I should see a popup dialog with content "CHANGE$0.00OK"
     When I click on the "OK" button in the popup dialog
     Then I should be redirected to HOME page
+
+    When I clock out the timesheet with PIN "8903"
 
   Scenario: Update GC balance when making multiple payments using 2 GCs
     Given I am on the HOME page
@@ -1052,6 +1098,8 @@ Feature: Create tickets
     And I should see the first type "Redeem" in the gift card detail list
     And I should see the first amount "($35.80)" in the gift card detail list
 
+    When I clock out the timesheet with PIN "8526"
+
   Scenario: Apply auto-discount item and change it to another
     Given I am on the HOME page
     When I clock in the timesheet with PIN "9960"
@@ -1095,6 +1143,8 @@ Feature: Create tickets
     When I click on the "OK" button in the popup dialog
     Then I should be redirected to HOME page
 
+    When I clock out the timesheet with PIN "9960"
+
   Scenario: Queue - show Total, Last Service, Clock In Time
     Given I am on the HOME page
     When I clock in the timesheet with PIN "7779"
@@ -1130,6 +1180,8 @@ Feature: Create tickets
     When I reopen to void ticket with payment amount "$20.11"
     Then I should be redirected to HOME page
 
+    When I clock out the timesheet with PIN "7779"
+
   Scenario: In Service - show Service Count, Price Service Ticket
     Given I am on the HOME page
     When I clock in the timesheet with PIN "5839"
@@ -1161,3 +1213,5 @@ Feature: Create tickets
     And I should see a popup dialog with content "CHANGE$0.00OK"
     When I click on the "OK" button in the popup dialog
     Then I should be redirected to HOME page
+
+    When I clock out the timesheet with PIN "5839"

--- a/e2e/pos-web/src/features/payroll.feature
+++ b/e2e/pos-web/src/features/payroll.feature
@@ -148,6 +148,7 @@ Feature: Payroll
     # And I should not see the employee "Sydney" in the ticket list
     When I wait for the page fully loaded
     And I delete ticket after void it with payment amount "215.70"
+    And I clock out the timesheet with PIN "6789"
 
   Scenario: Commission payroll details in the Owner View are calculated correctly
     Given I am on the HOME page
@@ -233,6 +234,7 @@ Feature: Payroll
     # And I should not see the employee "Venus" in the ticket list
 
     When I delete ticket after void it with payment amount "225.70"
+    And I clock out the timesheet with PIN "9969"
 
   Scenario: Hourly payroll details in the Employee View are calculated correctly
     Given I am on the HOME page
@@ -303,7 +305,8 @@ Feature: Payroll
 
     When I reopen to void ticket with payment amount "$218.97"
     Then I should be redirected to HOME page
-    # And I should not see the employee "Jazzie" in the ticket list
+
+    When I clock out the timesheet with PIN "1314"
 
   Scenario: Hourly payroll details in the Owner View are calculated correctly
     Given I am on the HOME page
@@ -386,6 +389,7 @@ Feature: Payroll
 
     When I wait for the page fully loaded
     When I search for "Addison"
+    And I wait for the page fully loaded
     And I select the employee "Addison"
     Then I should see the Payroll Date default to today
     And I should see the technician name "Addison" in the employee view

--- a/e2e/pos-web/src/features/quick-payroll.feature
+++ b/e2e/pos-web/src/features/quick-payroll.feature
@@ -101,6 +101,7 @@ Feature: Quick payroll
     # And I should not see the employee "Serena" in the ticket list
 
     When I delete ticket after void it with payment amount "245.70"
+    When I clock out the timesheet with PIN "2771"
 
   Scenario: Display Hourly payroll details correctly in the payroll summary
     Given I am on the HOME page

--- a/e2e/pos-web/src/features/ticket-adjustment.feature
+++ b/e2e/pos-web/src/features/ticket-adjustment.feature
@@ -61,6 +61,9 @@ Feature: Fix Ticket
     And I wait for the page fully loaded
     Then I should see the text "Please select a ticket." in the ticket adjustment screen
 
+    When I back to HOME page
+    And I clock out the timesheet with PIN "8573"
+
   Scenario: View service details
     Given I am on the HOME page
     When I clock in the timesheet with PIN "9610"
@@ -127,6 +130,9 @@ Feature: Fix Ticket
     And I should see the detail "Item Supply Fee($3.00)"
     And I should see the detail "Package Amount$29.00"
     And I should see the detail "Commission$15.00"
+
+    When I back to HOME page
+    And I clock out the timesheet with PIN "9610"
 
   Scenario: Create a ticket for today, add tip, apply discount item and apply discount ticket
     Given I am on the HOME page
@@ -318,6 +324,9 @@ Feature: Fix Ticket
     And I wait for the page fully loaded
     Then I should see the text "Please select a ticket." in the ticket adjustment screen
 
+    When I back to HOME page
+    And I clock out the timesheet with PIN "3412"
+
   Scenario: Change tech and split tip
     Given I am on the HOME page
     When I clock in the timesheet with PIN "8414"
@@ -382,6 +391,9 @@ Feature: Fix Ticket
     When I click on the "SAVE" button in the popup dialog
     And I wait for the page fully loaded
     Then I should see the text "Please select a ticket." in the ticket adjustment screen
+
+    When I back to HOME page
+    And I clock out the timesheet with PIN "8414"
 
   Scenario: Update GC balance after voiding a sell Gift Card
     Given I am on the HOME page
@@ -463,6 +475,7 @@ Feature: Fix Ticket
 
     When I back to HOME page
     And I wait for the page fully loaded
+    And I clock out the timesheet with PIN "5720"
 
     Given I am on the GIFT_CARD_BALANCE page
     When I enter the amount "0503"
@@ -532,6 +545,9 @@ Scenario: Remove Tax and make new payment
     And I wait for the page fully loaded
     Then I should see the text "Please select a ticket." in the ticket adjustment screen
 
+    When I back to HOME page
+    And I clock out the timesheet with PIN "8754"
+
   Scenario: Add Tax and make new payment
     Given I am on the HOME page
     When I clock in the timesheet with PIN "1648"
@@ -591,6 +607,9 @@ Scenario: Remove Tax and make new payment
     And I wait for the page fully loaded
     Then I should see the text "Please select a ticket." in the ticket adjustment screen
 
+    When I back to HOME page
+    And I clock out the timesheet with PIN "1648"
+
   Scenario: Update loyalty when adding a customer to the ticket
     Given I am on the HOME page
     When I clock in the timesheet with PIN "4170"
@@ -637,3 +656,5 @@ Scenario: Remove Tax and make new payment
     And I wait for the page fully loaded
     Then I should see the text "Please select a ticket." in the ticket adjustment screen
 
+    When I back to HOME page
+    And I clock out the timesheet with PIN "4170"

--- a/e2e/pos-web/src/features/ticket-payments.feature
+++ b/e2e/pos-web/src/features/ticket-payments.feature
@@ -87,6 +87,7 @@ Feature: Ticket Payments
     # And I should not see the employee "Hilary" in the ticket list
 
     When I delete ticket after void it with payment amount "228.70"
+    And I clock out the timesheet with PIN "1250"
 
   Scenario: The Services/Products tab displays data correctly
     Given I am on the HOME page
@@ -174,5 +175,5 @@ Feature: Ticket Payments
     # And I should not see the employee "Valerie" in the ticket list
 
     When I delete ticket after void it with payment amount "70.03"
-
+    And I clock out the timesheet with PIN "6118"
 

--- a/e2e/pos-web/src/features/tickets.feature
+++ b/e2e/pos-web/src/features/tickets.feature
@@ -38,6 +38,8 @@ Feature: Reopen tickets
     And I click on the "CLOSE TICKET" button
     Then I should be redirected to HOME page
 
+    When I clock out the timesheet with PIN "2429"
+
   Scenario: Reopen ticket to change tech for service package
     Given I am on the HOME page
     When I clock in the timesheet with PIN "9860"
@@ -84,6 +86,8 @@ Feature: Reopen tickets
 
     When I click on the "CLOSE TICKET" button
     Then I should be redirected to HOME page
+
+    When I clock out the timesheet with PIN "9860"
 
   Scenario: Reopen ticket to change technician and split tip
     Given I am on the HOME page
@@ -179,6 +183,8 @@ Feature: Reopen tickets
     And I click on the "CLOSE TICKET" button
     Then I should be redirected to HOME page
 
+    When I clock out the timesheet with PIN "3957"
+
   Scenario: Update GC balance after reopening to adjust tip
     Given I am on the HOME page
     When I clock in the timesheet with PIN "8888"
@@ -230,6 +236,8 @@ Feature: Reopen tickets
     And I should see the first type "Redeem" in the gift card detail list
     And I should see the first amount "($22.00)" in the gift card detail list
 
+    When I clock out the timesheet with PIN "8888"
+
   Scenario: Reopen ticket to remove payment Cash and instead of Credit
     Given I am on the HOME page
     When I clock in the timesheet with PIN "4683"
@@ -274,6 +282,8 @@ Feature: Reopen tickets
     And I fill the last 4 digits of card number "1234"
     And I click on the element with id "payment"
     Then I should be redirected to HOME page
+
+    When I clock out the timesheet with PIN "4683"
 
   Scenario: Reopen ticket to change split tip Percent to Equal
     Given I am on the HOME page
@@ -335,6 +345,8 @@ Feature: Reopen tickets
     When I click on the "CLOSE TICKET" button
     Then I should be redirected to HOME page
 
+    When I clock out the timesheet with PIN "2174"
+
   Scenario: Reopen ticket to add service and make payment Credit
     Given I am on the HOME page
     When I clock in the timesheet with PIN "7139"
@@ -379,6 +391,8 @@ Feature: Reopen tickets
     And I click on the element with id "payment"
     Then I should be redirected to HOME page
 
+    When I clock out the timesheet with PIN "7139"
+
   Scenario: Reopen ticket to void ticket
     Given I am on the HOME page
     When I clock in the timesheet with PIN "5971"
@@ -410,7 +424,8 @@ Feature: Reopen tickets
 
     When I reopen to void ticket with payment amount "$16.48"
     Then I should be redirected to HOME page
-    # And I should not see the employee "Daisy" in the ticket list
+
+    When I clock out the timesheet with PIN "5971"
 
   Scenario: Reopen ticket to void item, remove and make new payment
     Given I am on the HOME page
@@ -461,6 +476,8 @@ Feature: Reopen tickets
     And I click on the element with id "payment"
     Then I should be redirected to HOME page
 
+    When I clock out the timesheet with PIN "8546"
+
   Scenario: Update GC balance when selling an add-on gift card and then voiding the ticket
     Given I am on the HOME page
     When I clock in the timesheet with PIN "2463"
@@ -510,6 +527,8 @@ Feature: Reopen tickets
     When I search gift card "2030"
     Then I should see the first type "ActivateNew" in the gift card detail list
     And I should see the first amount "$50.00" in the gift card detail list
+
+    When I clock out the timesheet with PIN "2463"
 
   Scenario: Cannot find gift card after selling a new gift card and then voiding the item Gift Card
     Given I am on the HOME page
@@ -576,9 +595,11 @@ Feature: Reopen tickets
     Then I should see a popup dialog containing the title "ACTIVATE GIFT CARD"
     And I should see a popup dialog with content "Do you want to activate gift card #2003"
 
+    When I clock out the timesheet with PIN "6727"
+
   Scenario: Cannot find gift card after selling a new gift card and then voiding the ticket
     Given I am on the HOME page
-    When I clock in the timesheet with PIN "01"
+    When I clock in the timesheet with PIN "0001"
     Then I should see the employee "Leon" in the employee list
     When I select the "Leon" employee
     Then I should see the "Ticket View" screen
@@ -623,6 +644,8 @@ Feature: Reopen tickets
     Then I should see a popup dialog containing the title "ACTIVATE GIFT CARD"
     And I should see the toast message "Can't find gift card." visible
 
+    When I clock out the timesheet with PIN "0001"
+
   Scenario: Remove loyalty balance when voiding ticket
     Given I am on the HOME page
     When I clock in the timesheet with PIN "7217"
@@ -665,6 +688,8 @@ Feature: Reopen tickets
 
     Then I should see the text "Customer: Jimmy" visible
     And I should see the text "No rows" visible
+
+    When I clock out the timesheet with PIN "7217"
 
   Scenario: View the loyalty point on Receipt
     Given I am on the HOME page
@@ -770,6 +795,8 @@ Feature: Reopen tickets
 
     Then I should see the QR code on the receipt
 
+    When I clock out the timesheet with PIN "2883"
+
   Scenario: Update gift card balance correctly after voiding a gift card payment and paying with cash
     Given I am on the HOME page
     When I clock in the timesheet with PIN "6566"
@@ -821,6 +848,8 @@ Feature: Reopen tickets
     And I should see the first type "ActivateNew" in the gift card detail list
     And I should see the first amount "$100.00" in the gift card detail list
 
+    When I clock out the timesheet with PIN "6566"
+
   Scenario: Update gift card balance after increasing the tip via Adjust Tip of GC payment
     Given I am on the HOME page
     When I clock in the timesheet with PIN "4377"
@@ -869,6 +898,8 @@ Feature: Reopen tickets
     Then I should see the first date is today in the gift card detail list
     And I should see the first amount "($27.50)" in the gift card detail list
     And I should see the first type "Redeem" in the gift card detail list
+
+    When I clock out the timesheet with PIN "4377"
 
   Scenario: CC slip after adjusting tip
     Given I am on the HOME page
@@ -947,6 +978,8 @@ Feature: Reopen tickets
     When I void the current open ticket with reason "Mistake"
     Then I should be redirected to HOME page
 
+    When I clock out the timesheet with PIN "8959"
+
   Scenario: CC slip with no tip
     Given I am on the HOME page
     When I clock in the timesheet with PIN "5672"
@@ -1006,6 +1039,8 @@ Feature: Reopen tickets
     When I void the current open ticket with reason "Mistake"
     Then I should be redirected to HOME page
 
+    When I clock out the timesheet with PIN "5672"
+
   Scenario: Work slip receipt details
     Given I am on the HOME page
     When I clock in the timesheet with PIN "6374"
@@ -1063,6 +1098,8 @@ Feature: Reopen tickets
 
     When I void the current open ticket with reason "Mistake"
     Then I should be redirected to HOME page
+
+    When I clock out the timesheet with PIN "6374"
 
   Scenario: Work slip update after adjusting tip
     Given I am on the HOME page
@@ -1139,6 +1176,8 @@ Feature: Reopen tickets
 
     When I void the current open ticket with reason "Mistake"
     Then I should be redirected to HOME page
+
+    When I clock out the timesheet with PIN "9606"
 
   @skip
   Scenario: Closed ticket number sort by Descending

--- a/e2e/pos-web/src/features/turn-details.feature
+++ b/e2e/pos-web/src/features/turn-details.feature
@@ -135,7 +135,8 @@ Feature: Turn details
 
     When I reopen to void ticket with payment amount "$23.58"
     Then I should be redirected to HOME page
-    # And I should not see the employee "Zoey" in the ticket list
+
+    When I clock out the timesheet with PIN "3818"
 
   Scenario: Manually adding decrease a turn reorders the employee queue
     Given I am on the HOME page
@@ -240,9 +241,11 @@ Feature: Turn details
     When I hold the "Late Turn" employee two seconds
     Then I should see the "TURN" Adjustment
     When I click on the "Remove Late Turn" in turn adjustment
-     And I wait for the page fully loaded
+    And I wait for the page fully loaded
     And I waiting 1s
     Then I should see Employee "Late Turn" with "Turn: 0.0" in the employee list
+
+    When I clock out the timesheet with PIN "0210"
 
   Scenario: Adjust turn - Add Go Again, Remove Go Again
     Given I am on the HOME page
@@ -294,6 +297,7 @@ Feature: Turn details
     And I should see Employee "Go Again" with "Turn: 0.0" in the employee list
 
     When I delete ticket after void it with payment amount "21.26"
+    And I clock out the timesheet with PIN "0466"
 
   Scenario: Adjust turn - Move, Remove Move
     Given I am on the HOME page
@@ -315,6 +319,8 @@ Feature: Turn details
     When I click on the "Remove Move" in turn adjustment
     And I wait for the page fully loaded
     Then I should see the employee "Move" is not at position 1
+
+    When I clock out the timesheet with PIN "5781"
 
   Scenario: View turn details correctly on the receipt
     Given I am on the HOME page
@@ -371,3 +377,5 @@ Feature: Turn details
 
     When I reopen to void ticket with payment amount "$255.70"
     Then I should be redirected to HOME page
+
+    When I clock out the timesheet with PIN "3328"


### PR DESCRIPTION
## Summary by Sourcery

Ensure end-to-end POS web scenarios properly close technician sessions by clocking employees out after test flows, and align timesheet PINs used across related tests.

Tests:
- Add explicit clock-out steps with the appropriate technician PIN at the end of POS web create-ticket, ticket, ticket-adjustment, turn-details, payroll, ticket-payments, close-out, quick-payroll, and related Galaxy Pink e2e scenarios to clean up timesheet state between tests.
- Update timesheet PINs in gift-card balance scenarios to use consistent, zero-padded values across online and offline POS web tests.