### PR TITLE
feat(galaxy-pink-web): close ticket 0.00, services and discount item …

### DIFF
--- a/e2e/galaxy-pink-web/src/features/create-tickets.feature
+++ b/e2e/galaxy-pink-web/src/features/create-tickets.feature
@@ -12,6 +12,9 @@ Feature: Create tickets
     And I should see the loyalty program "2 Points = $1" visible
     And I should see the loyalty program list displayed correctly
 
+    When I close the opening dialog
+    And I void the current open ticket with reason "System Test"
+
   Scenario: Card fee is calculated correctly for cash discounts
     Given I am on the HOME page
     When I clock in the timesheet with PIN "5254"
@@ -79,7 +82,6 @@ Feature: Create tickets
 
     When I reopen to void ticket with payment amount "$6.11"
     Then I should see the selected "SERVICE" tab on the Home page
-    # And I should not see the employee "Owner" in the ticket list
 
   Scenario: Update redeem after paying with Loyalty points
     Given I am on the HOME page
@@ -983,3 +985,47 @@ Feature: Create tickets
     When I click ticket of customer "InService"
     And I pay the exact amount by "Cash"
     Then I should see the selected "SERVICE" tab on the Home page
+
+  Scenario: Can close ticket $0.00
+    Given I am on the HOME page
+    When I clock in the timesheet with PIN "3732"
+    Then I should see the employee "Freya" in the employee list
+
+    When I select the "Freya" employee
+    Then I should see the "Ticket View" screen
+    And I should see the "Manicure" service
+    When I add the "Supper combo" service to my cart
+    Then I should see my cart showing 1 item added
+
+    When I click on the "Pay" button
+    And I click on the "Close Ticket" button
+    Then I should see the selected "SERVICE" tab on the Home page
+
+    When I clock out the timesheet with PIN "3732"
+
+  Scenario: Services are displayed in the correct order
+    Given I am on the HOME page
+    When I clock in the timesheet with PIN "4831"
+    And I wait for the page fully loaded
+    Then I should see the employee "Calantha" in the employee list
+    When I select the "Calantha" employee
+    Then I should see the "Ticket View" screen
+    And I should see the services displayed correctly in ticket view
+    When I void the current open ticket with reason "System Test"
+
+  Scenario: Discount items are in the correct order
+    Given I am on the HOME page
+    When I clock in the timesheet with PIN "4831"
+    And I wait for the page fully loaded
+    Then I should see the employee "Calantha" in the employee list
+    When I select the "Calantha" employee
+    Then I should see the "Ticket View" screen
+
+    When I add the "Manicure" service to my cart
+    And I select the service "Manicure" in my cart
+    And I select the "DISCOUNT ITEM" on the menu
+    Then I should see the discount sorted correctly
+
+    When I click on the "Cancel" button
+    And I void the current open ticket with reason "System Test"
+

--- a/e2e/galaxy-pink-web/src/features/steps.ts
+++ b/e2e/galaxy-pink-web/src/features/steps.ts
@@ -1067,14 +1067,6 @@ When('I select the {string} discount type', async ({ page }, type: string) => {
 });
 
 Then('I should see the discount sorted correctly', async ({ page }) => {
-	const discountItems = page.locator('.listDiscount__item ul li p');
-	const count = await discountItems.count();
-
-	const texts: string[] = [];
-
-	for (let i = 0; i < count; i++) {
-		texts.push((await discountItems.nth(i).innerText()).trim());
-	}
 	const expectedOrder = [
 		'Open Discount',
 		'$5 Off',
@@ -1083,7 +1075,9 @@ Then('I should see the discount sorted correctly', async ({ page }) => {
 		'20% Off - exclude Product',
 	];
 
-	await expect(texts).toEqual(expectedOrder);
+	const discountItems = page.locator('.listDiscount__item ul li p');
+
+	await expect(discountItems).toHaveText(expectedOrder);
 });
 
 When('I select the discount {string}', async ({ page }, discount: string) => {
@@ -4968,5 +4962,32 @@ Then(
 
 		await expect(employeeRow).toBeVisible();
 		await expect(totalPrice).toHaveText(expectedPrice);
+	},
+);
+
+Then(
+	'I should see the services displayed correctly in ticket view',
+	async ({ page }) => {
+		const expectedServices = [
+			'Manicure',
+			'Pedicure',
+			'Cut cuticle',
+			'Gel removal',
+			'Acrylic removal',
+			'Gel X',
+			'Request price',
+			'Combo 1',
+			'Combo 2',
+			'Supper combo',
+		];
+
+		const serviceElements = page.locator(
+			'li.ItemService .ItemService__name span',
+		);
+		await expect(serviceElements).toHaveText(expectedServices, {
+			timeout: 5000,
+		});
+
+		console.log('Validated all services display in correct order.');
 	},
 );

--- a/e2e/galaxy-pink-web/src/steps/ticket-view.page.ts
+++ b/e2e/galaxy-pink-web/src/steps/ticket-view.page.ts
@@ -45,14 +45,18 @@ class TicketViewPage extends xPage {
 			/**
 			 * Locate a reason when voiding a ticket that has been changed status to "DONE"
 			 */
-			voidReasonDialog: super.locators.dialog('SELECT VOID REASON'),
+			voidReasonDialog: page.locator('.xTicketFunctions__content', {
+				has: page.locator(
+					'.xTicketFunctions__title >> text=SELECT VOID REASON',
+				),
+			}),
 		};
 	}
 
 	/**
 	 * Get the current ticket number shown on the page header
 	 */
-	public async getTicketNumber() {
+	public async getTicketNumber(): Promise<string | undefined> {
 		const pageDetail = await this.locators.pageDetail.textContent();
 
 		return pageDetail?.split('#')[1]?.trim();
@@ -64,39 +68,41 @@ class TicketViewPage extends xPage {
 	 * Void the current ticket on screen
 	 */
 	@When('I void the current open ticket with no reason')
-	public async voidTicket(reason = 'Mistake') {
-		const { locators } = this;
+	public async voidTicket(reason?: string) {
+		const { locators, page } = this;
 
-		// store the ticket number for later assertion
 		const ticketNumber = await this.getTicketNumber();
 
-		// click the void button
 		await locators.voidButton.click();
 		const voidReasonDialog = locators.voidReasonDialog;
-		const voidTicketConfirmDialog = locators.dialog('VOID TICKET');
+		const voidTicketConfirmDialog = page.locator('.xTicketFunctions__content', {
+			has: page.locator('.xTicketFunctions__title >> text=VOID TICKET'),
+		});
 
-		// wait for 1 of 2 dialog types to be visible
 		await expect(voidReasonDialog.or(voidTicketConfirmDialog)).toBeVisible();
 
 		if (await voidReasonDialog.isVisible()) {
-			// in case the services associate with this ticket have changed status to DONE
-			// select a reason for voiding the ticket
-			await voidReasonDialog.getByText(reason).click();
+			if (reason) {
+				await voidReasonDialog
+					.locator('li')
+					.getByText(reason, { exact: true })
+					.click();
+			}
 
-			// waiting for the subsequent confirm dialog to be visible
 			const confirmDialog = locators.draggableDialog('CONFIRM VOID');
 			await expect(confirmDialog).toBeVisible();
 
 			await confirmDialog.getByRole('button', { name: 'CONFIRM' }).click();
-		} else {
-			// in case there's no service status changed to DONE
+		} else if (await voidTicketConfirmDialog.isVisible()) {
 			await voidTicketConfirmDialog.getByRole('button', { name: 'OK' }).click();
 
-			await expect(
-				locators.toast.getByText(
-					`Ticket ${ticketNumber} deleted successfully.`,
-				),
-			).toBeVisible();
+			if (ticketNumber) {
+				await expect(
+					locators.toast.getByText(
+						`Ticket ${ticketNumber} deleted successfully.`,
+					),
+				).toBeVisible();
+			}
 		}
 	}
 

--- a/e2e/pos-web/src/features/create-tickets.feature
+++ b/e2e/pos-web/src/features/create-tickets.feature
@@ -1215,3 +1215,41 @@ Feature: Create tickets
     Then I should be redirected to HOME page
 
     When I clock out the timesheet with PIN "5839"
+
+  Scenario: Can close ticket $0.00
+    Given I am on the HOME page
+    When I clock in the timesheet with PIN "3732"
+    Then I should see the employee "Freya" in the employee list
+
+    When I select the "Freya" employee
+    Then I should see the "Ticket View" screen
+    And I should see the "Manicure" service
+    When I add the "Supper combo" service to my cart
+    Then I should see my cart showing 1 item added
+
+    When I click on the "PAY" button
+    And I click on the "CLOSE TICKET" button
+    And I clock out the timesheet with PIN "3732"
+
+  Scenario: Services are displayed in the correct order
+    Given I am on the HOME page
+    When I clock in the timesheet with PIN "4831"
+    Then I should see the employee "Calantha" in the employee list
+    When I select the "Calantha" employee
+    Then I should see the "Ticket View" screen
+    And I should see the services displayed correctly in ticket view
+    When I void the current open ticket with reason "System Test"
+
+  Scenario: Discount items are in the correct order
+    Given I am on the HOME page
+    When I clock in the timesheet with PIN "4831"
+    Then I should see the employee "Calantha" in the employee list
+    When I select the "Calantha" employee
+    Then I should see the "Ticket View" screen
+
+    When I add the "Manicure" service to my cart
+    And I click on the item "DISCOUNT ITEM" button
+    And I select the "Manicure" service in the dialog
+    Then I should see the discount sorted correctly
+    When I close the popup dialog
+    And I void the current open ticket with reason "System Test"

--- a/e2e/pos-web/src/features/steps.ts
+++ b/e2e/pos-web/src/features/steps.ts
@@ -4394,3 +4394,48 @@ Then(
 		await expect(totalPrice).toHaveText(expectedPrice);
 	},
 );
+
+Then(
+	'I should see the services displayed correctly in ticket view',
+	async ({ page }) => {
+		const expectedServices = [
+			'Manicure',
+			'Pedicure',
+			'Cut cuticle',
+			'Gel removal',
+			'Acrylic removal',
+			'Gel X',
+			'Request price',
+			'Combo 1',
+			'Combo 2',
+			'Supper combo',
+		];
+
+		const serviceElements = page.locator(
+			'li.ItemService .ItemService__name span',
+		);
+		await expect(serviceElements).toHaveText(expectedServices, {
+			timeout: 5000,
+		});
+
+		console.log('Validated all services display in correct order.');
+	},
+);
+
+Then('I should see the discount sorted correctly', async ({ page }) => {
+	const expectedOrder = [
+		'Open Discount',
+		'$5 Off',
+		'5% Off',
+		'10% Off',
+		'20% Off - exclude Product',
+	];
+
+	const discountItems = page.locator('.listDiscount__item ul li p');
+
+	await expect(discountItems).toHaveText(expectedOrder);
+});
+
+When('I close the popup dialog', async ({ page }) => {
+	await page.locator('button[title="Close"]').click();
+});


### PR DESCRIPTION
…order correctly

## Summary by Sourcery

Add end-to-end coverage for closing $0.00 tickets and validating service/discount ordering, while refining ticket voiding behavior and shared step definitions.

New Features:
- Add e2e scenarios for closing $0.00 tickets in both Galaxy Pink web and POS web flows.
- Add e2e scenarios to verify services and discount items are displayed in the correct order in ticket view for Galaxy Pink web and POS web.

Enhancements:
- Refine ticket voiding step to handle optional void reasons, improved dialog targeting, and conditional success toast assertions.
- Simplify and reuse discount ordering and service ordering assertions using direct locator text expectations across test suites.
- Introduce a generic step to close popup dialogs in the POS web tests and close initial dialogs before running some Galaxy Pink web scenarios.

Tests:
- Expand create-tickets feature specs and step definitions to cover ticket closing, service ordering, and discount ordering behaviors across web experiences.