### PR TITLE
feat(galaxy-pink-web): add multiple discounts

### DIFF
--- a/e2e/galaxy-pink-web/src/features/close-out.feature
+++ b/e2e/galaxy-pink-web/src/features/close-out.feature
@@ -13,6 +13,7 @@ Feature: Close Out report
   Scenario: Technician report display correctly
     Given I am on the HOME page
     When I clock in the timesheet with PIN "7518"
+    And I wait for the page fully loaded
     Then I should see the employee "Elena" in the employee list
 
     When I select the "Elena" employee
@@ -78,9 +79,12 @@ Feature: Close Out report
     When I reopen to void ticket with payment amount "$235.35"
     Then I should see the selected "SERVICE" tab on the Home page
 
+    When I clock out the timesheet with PIN "7518"
+
   Scenario: Technician report summary display correctly
     Given I am on the HOME page
     When I clock in the timesheet with PIN "7298"
+    And I wait for the page fully loaded
     Then I should see the employee "Gemma" in the employee list
 
     When I select the "Gemma" employee
@@ -132,3 +136,5 @@ Feature: Close Out report
     When I reopen to void ticket with payment amount "$236.38"
     Then I should see the selected "SERVICE" tab on the Home page
     # And I should not see the employee "Gemma" in the ticket list
+
+    When I clock out the timesheet with PIN "7298"

--- a/e2e/galaxy-pink-web/src/features/closed-ticket.feature
+++ b/e2e/galaxy-pink-web/src/features/closed-ticket.feature
@@ -4,6 +4,7 @@ Feature: Closed Ticket
   Scenario: Reopen ticket then close ticket
     Given I am on the HOME page
     When I clock in the timesheet with PIN "2429"
+    And I wait for the page fully loaded
     Then I should see the employee "Chloe" in the employee list
 
     When I select the "Chloe" employee
@@ -35,6 +36,8 @@ Feature: Closed Ticket
     Then I should see the payment history "Cash $11.50" visible
     When I click on the "Close Ticket" button
     Then I should see the selected "SERVICE" tab on the Home page
+
+    When I clock out the timesheet with PIN "2429"
 
   Scenario: Reopen ticket to change tech for service package
     Given I am on the HOME page
@@ -78,9 +81,12 @@ Feature: Closed Ticket
     When I click on the "Close Ticket" button
     Then I should see the selected "SERVICE" tab on the Home page
 
+    When I clock out the timesheet with PIN "9860"
+
   Scenario: Reopen ticket to change technician and split tip
     Given I am on the HOME page
     When I clock in the timesheet with PIN "6373"
+    And I wait for the page fully loaded
     Then I should see the employee "Mia" in the employee list
 
     When I select the "Mia" employee
@@ -184,9 +190,12 @@ Feature: Closed Ticket
     When I click on the "Close Ticket" button
     Then I should see the selected "SERVICE" tab on the Home page
 
+    When I clock out the timesheet with PIN "3957"
+
   Scenario: Reopen ticket to remove payment Cash and instead of Credit
     Given I am on the HOME page
     When I clock in the timesheet with PIN "4683"
+    And I wait for the page fully loaded
     Then I should see the employee "Samantha" in the employee list
 
     When I select the "Samantha" employee
@@ -229,9 +238,12 @@ Feature: Closed Ticket
     When I click on the "Close Ticket" button
     Then I should see the selected "SERVICE" tab on the Home page
 
+    When I clock out the timesheet with PIN "4683"
+
   Scenario: Reopen ticket to change split tip Percent to Equal
     Given I am on the HOME page
     When I clock in the timesheet with PIN "2174"
+    And I wait for the page fully loaded
     Then I should see the employee "Daniel" in the employee list
 
     When I select the "Daniel" employee
@@ -285,9 +297,12 @@ Feature: Closed Ticket
     When I click on the "OK" button
     Then I should see the selected "SERVICE" tab on the Home page
 
+    When I clock out the timesheet with PIN "2174"
+
   Scenario: Reopen ticket to add service and make payment Credit
     Given I am on the HOME page
     When I clock in the timesheet with PIN "7139"
+    And I wait for the page fully loaded
     Then I should see the employee "Julia" in the employee list
 
     When I select the "Julia" employee
@@ -328,9 +343,12 @@ Feature: Closed Ticket
     When I click on the "Close Ticket" button
     Then I should see the selected "SERVICE" tab on the Home page
 
+    When I clock out the timesheet with PIN "7139"
+
   Scenario: Reopen ticket to void ticket
     Given I am on the HOME page
     When I clock in the timesheet with PIN "5971"
+    And I wait for the page fully loaded
     Then I should see the employee "Daisy" in the employee list
 
     When I select the "Daisy" employee
@@ -361,11 +379,13 @@ Feature: Closed Ticket
 
     When I reopen to void ticket with payment amount "$16.48"
     Then I should see the selected "SERVICE" tab on the Home page
-    # And I should not see the employee "Daisy" in the ticket list
+
+    When I clock out the timesheet with PIN "5971"
 
   Scenario: Reopen ticket to void item, remove and make new payment
     Given I am on the HOME page
     When I clock in the timesheet with PIN "8546"
+    And I wait for the page fully loaded
     Then I should see the employee "Fiona" in the employee list
 
     When I select the "Fiona" employee
@@ -423,9 +443,12 @@ Feature: Closed Ticket
     When I click on the "Close Ticket" button
     Then I should see the selected "SERVICE" tab on the Home page
 
+    When I clock out the timesheet with PIN "8546"
+
   Scenario: Update GC balance when selling an add-on gift card and then voiding the ticket
     Given I am on the HOME page
     When I clock in the timesheet with PIN "2463"
+    And I wait for the page fully loaded
     Then I should see the employee "Isabella" in the employee list
     When I select the "Isabella" employee
     Then I should see the "Ticket View" screen
@@ -463,9 +486,13 @@ Feature: Closed Ticket
     Then I should see the first type "ActivateAddOn" in the gift card detail list
     And I should see the first amount "$50.00" in the gift card detail list
 
+    When I back to HOME page
+    And I clock out the timesheet with PIN "2463"
+
   Scenario: Cannot find gift card after selling a new gift card and then voiding the item Gift Card
     Given I am on the HOME page
     When I clock in the timesheet with PIN "6727"
+    And I wait for the page fully loaded
     Then I should see the employee "Alexis" in the employee list
     When I select the "Alexis" employee
     Then I should see the "Ticket View" screen
@@ -527,9 +554,13 @@ Feature: Closed Ticket
     Then I should see a popup dialog containing the title "ACTIVATE GIFT CARD"
     And I should see a popup dialog with content "Do you want to activate gift card #2003"
 
+    When I back to HOME page
+    And I clock out the timesheet with PIN "6727"
+
   Scenario: Remove loyalty balance when voiding ticket
     Given I am on the HOME page
     When I clock in the timesheet with PIN "7217"
+    And I wait for the page fully loaded
     Then I should see the employee "Charlotte" in the employee list
     When I select the "Charlotte" employee
     Then I should see the "Ticket View" screen
@@ -564,9 +595,13 @@ Feature: Closed Ticket
     And I wait for the page fully loaded
     Then I should see the text "No rows" visible
 
+    When I back to HOME page
+    And I clock out the timesheet with PIN "7217"
+
   Scenario: View the loyalty point on Receipt
     Given I am on the HOME page
     When I clock in the timesheet with PIN "2883"
+    And I wait for the page fully loaded
     Then I should see the employee "Gabriella" in the employee list
     When I select the "Gabriella" employee
     And I add the "Manicure" service to my cart
@@ -658,10 +693,12 @@ Feature: Closed Ticket
     And I should see the tip guide "20% TIP = $5.85" on the receipt
 
     Then I should see the QR code on the receipt
+    When I clock out the timesheet with PIN "2883"
 
   Scenario: Update gift card balance correctly after voiding a gift card payment and paying with cash
     Given I am on the HOME page
     When I clock in the timesheet with PIN "6566"
+    And I wait for the page fully loaded
     Then I should see the employee "Willow" in the employee list
 
     When I select the "Willow" employee
@@ -717,9 +754,13 @@ Feature: Closed Ticket
     Then I should see the first type "ActivateNew" in the gift card detail list
     And I should see the first amount "$100.00" in the gift card detail list
 
+    When I back to HOME page
+    And I clock out the timesheet with PIN "6566"
+
   Scenario: CC slip after adjusting tip
     Given I am on the HOME page
     When I clock in the timesheet with PIN "8959"
+    And I wait for the page fully loaded
     Then I should see the employee "CC_Slip" in the employee list
 
     When I select the "CC_Slip" employee
@@ -795,11 +836,13 @@ Feature: Closed Ticket
 
     When I reopen to void ticket with payment amount "$234.22"
     Then I should see the selected "SERVICE" tab on the Home page
-    # And I should not see the employee "CC_Slip" in the ticket list
+
+    When I clock out the timesheet with PIN "8959"
 
   Scenario: CC slip with no tip
     Given I am on the HOME page
     When I clock in the timesheet with PIN "5672"
+    And I wait for the page fully loaded
     Then I should see the employee "CCSlipNoTip" in the employee list
 
     When I select the "CCSlipNoTip" employee
@@ -854,11 +897,13 @@ Feature: Closed Ticket
 
     When I reopen to void ticket with payment amount "$241.48"
     Then I should see the selected "SERVICE" tab on the Home page
-    # And I should not see the employee "CCSlipNoTip" in the ticket list
+
+    When I clock out the timesheet with PIN "5672"
 
   Scenario: Work slip receipt details
     Given I am on the HOME page
     When I clock in the timesheet with PIN "6374"
+    And I wait for the page fully loaded
     Then I should see the employee "WorkSlip" in the employee list
 
     When I select the "WorkSlip" employee
@@ -913,11 +958,13 @@ Feature: Closed Ticket
 
     When I reopen to void ticket with payment amount "$254.57"
     Then I should see the selected "SERVICE" tab on the Home page
-    # And I should not see the employee "WorkSlip" in the ticket list
-@fix
+
+    When I clock out the timesheet with PIN "6374"
+
   Scenario: Work slip update after adjusting tip
     Given I am on the HOME page
     When I clock in the timesheet with PIN "9606"
+    And I wait for the page fully loaded
     Then I should see the employee "WorkSlipAdjustTip" in the employee list
 
     When I select the "WorkSlipAdjustTip" employee
@@ -993,7 +1040,8 @@ Feature: Closed Ticket
 
     When I reopen to void ticket with payment amount "$244.27"
     Then I should see the selected "SERVICE" tab on the Home page
-    # And I should not see the employee "WorkSlipAdjustTip" in the ticket list
+
+    When I clock out the timesheet with PIN "9606"
   @skip
   Scenario: Closed ticket number sort by Descending
     Given I am on the HOME page
@@ -1025,6 +1073,7 @@ Feature: Closed Ticket
   Scenario: Filter technician
     Given I am on the HOME page
     When I clock in the timesheet with PIN "1234"
+    And I wait for the page fully loaded
     Then I should see the employee "Owner" in the employee list
 
     When I select the "Owner" employee

--- a/e2e/galaxy-pink-web/src/features/create-tickets.feature
+++ b/e2e/galaxy-pink-web/src/features/create-tickets.feature
@@ -34,6 +34,8 @@ Feature: Create tickets
     When I click on the "confirm" button in the popup dialog
     Then I should see the selected "SERVICE" tab on the Home page
 
+    When I clock out the timesheet with PIN "5254"
+
   Scenario: Display correct category and service data
     Given I am on the HOME page
     When I clock in the timesheet with PIN "0917"
@@ -118,6 +120,9 @@ Feature: Create tickets
     And I should see the first type "Issuance" in the loyalty detail list
     And I should see the first amount "0" in the gift card detail list
 
+    When I back to HOME page
+    And I clock out the timesheet with PIN "8102"
+
   Scenario: Create a new customer on the fly
     Given I am on the HOME page
     When I clock in the timesheet with PIN "0917"
@@ -161,6 +166,8 @@ Feature: Create tickets
     When I pay the exact amount by "Cash"
     Then I should see the selected "SERVICE" tab on the Home page
 
+    When I clock out the timesheet with PIN "2860"
+
   Scenario: Create a ticket, add Tip and pay with Credit card
     Given I am on the HOME page
     When I clock in the timesheet with PIN "0101"
@@ -182,9 +189,11 @@ Feature: Create tickets
     When I click on the "Close Ticket" button
     Then I should see the selected "SERVICE" tab on the Home page
 
+    When I clock out the timesheet with PIN "0101"
+
   Scenario: Verify that the balance is updated correctly when paying with a gift card
     Given I am on the HOME page
-    When I clock in the timesheet with PIN "4"
+    When I clock in the timesheet with PIN "0004"
     Then I should see the employee "Emma" in the employee list
     When I select the "Emma" employee
     Then I should see the "Ticket View" screen
@@ -213,6 +222,9 @@ Feature: Create tickets
     And I should see the first type "Redeem" in the gift card detail list
     And I should see the first amount "($6.00)" in the gift card detail list
 
+    When I back to HOME page
+    And I clock out the timesheet with PIN "0004"
+
   Scenario: Create a ticket and pay with Debit type
     Given I am on the HOME page
     When I clock in the timesheet with PIN "0505"
@@ -231,6 +243,8 @@ Feature: Create tickets
     Then I should see the payment history "DEBIT (1234)$6.00" visible
     When I click on the "Close Ticket" button
     Then I should see the selected "SERVICE" tab on the Home page
+
+    When I clock out the timesheet with PIN "0505"
 
   Scenario: Split tip by Percent on ticket after paying by Credit card
     Given I am on the HOME page
@@ -266,6 +280,8 @@ Feature: Create tickets
     When I click on the "OK" button
     Then I should see the selected "SERVICE" tab on the Home page
 
+    When I clock out the timesheet with PIN "0202"
+
   Scenario: Create a ticket and pay with Cash change
     Given I am on the HOME page
     When I clock in the timesheet with PIN "9076"
@@ -283,6 +299,8 @@ Feature: Create tickets
     And I should see a popup dialog with content "CHANGE$60.00OK"
     When I click on the "OK" button in the popup dialog
     Then I should see the selected "SERVICE" tab on the Home page
+
+    When I clock out the timesheet with PIN "9076"
 
   Scenario: Make multiple payments using Gift Card and Credit
     Given I am on the HOME page
@@ -312,6 +330,8 @@ Feature: Create tickets
     When I click on the "Close Ticket" button
     Then I should see the selected "SERVICE" tab on the Home page
 
+    When I clock out the timesheet with PIN "1219"
+
   Scenario: Change price and add request for service in ticket
     Given I am on the HOME page
     When I clock in the timesheet with PIN "1828"
@@ -334,6 +354,8 @@ Feature: Create tickets
 
     When I pay the exact amount by "Cash"
     Then I should see the selected "SERVICE" tab on the Home page
+
+    When I clock out the timesheet with PIN "1828"
 
   Scenario: Add the Open Discount amount for Discount item
     Given I am on the HOME page
@@ -360,6 +382,8 @@ Feature: Create tickets
 
     When I pay the exact amount by "Cash"
     Then I should see the selected "SERVICE" tab on the Home page
+
+    When I clock out the timesheet with PIN "8623"
 
   Scenario: Add the Open Discount percent for Discount ticket
     Given I am on the HOME page
@@ -390,6 +414,8 @@ Feature: Create tickets
     When I pay the exact amount by "Cash"
     Then I should see the selected "SERVICE" tab on the Home page
 
+    When I clock out the timesheet with PIN "9962"
+
   Scenario: Apply auto-discount item and change it to another
     Given I am on the HOME page
     When I clock in the timesheet with PIN "9960"
@@ -419,6 +445,8 @@ Feature: Create tickets
 
     When I pay the exact amount by "Cash"
     Then I should see the selected "SERVICE" tab on the Home page
+
+    When I clock out the timesheet with PIN "9960"
 
   Scenario: Sell a Gift Card add-on amount
     Given I am on the HOME page
@@ -456,9 +484,12 @@ Feature: Create tickets
     And I should see the first type "ActivateAddOn" in the gift card detail list
     And I should see the first amount "$100.00" in the gift card detail list
 
+    When I clock out the timesheet with PIN "1010"
+
   Scenario: Sell a Gift Card rewrite amount
     Given I am on the HOME page
     When I clock in the timesheet with PIN "5362"
+    And I wait for the page fully loaded
     Then I should see the employee "Sandy" in the employee list
     When I select the "Sandy" employee
     Then I should see the "Ticket View" screen
@@ -492,9 +523,13 @@ Feature: Create tickets
     And I should see the first type "Overwrite" in the gift card detail list
     And I should see the first amount "$100.00" in the gift card detail list
 
+    When I back to HOME page
+    And I clock out the timesheet with PIN "5362"
+
   Scenario: Remove tax in ticket
     Given I am on the HOME page
     When I clock in the timesheet with PIN "6993"
+    And I wait for the page fully loaded
     Then I should see the employee "Jack" in the employee list
     When I select the "Jack" employee
     And I select the "FULL SET & FILL IN" category
@@ -509,6 +544,8 @@ Feature: Create tickets
 
     When I pay the exact amount by "Cash"
     Then I should see the selected "SERVICE" tab on the Home page
+
+    When I clock out the timesheet with PIN "6993"
 
   Scenario: Void an empty ticket
     Given I am on the HOME page
@@ -629,6 +666,8 @@ Feature: Create tickets
     When I pay the exact amount by "Cash"
     Then I should see the selected "SERVICE" tab on the Home page
 
+    When I clock out the timesheet with PIN "0404"
+
   Scenario: Change Technician for Service package
     Given I am on the HOME page
     When I clock in the timesheet with PIN "6769"
@@ -652,6 +691,8 @@ Feature: Create tickets
 
     When I pay the exact amount by "Cash"
     Then I should see the selected "SERVICE" tab on the Home page
+
+    When I clock out the timesheet with PIN "6769"
 
   Scenario: Remove payment history and choose another one
     Given I am on the HOME page
@@ -722,6 +763,8 @@ Feature: Create tickets
     When I pay the exact amount by "Cash"
     Then I should see the selected "SERVICE" tab on the Home page
 
+    When I clock out the timesheet with PIN "2406"
+
   Scenario: Select Tech to split tip by percent
     Given I am on the HOME page
     When I clock in the timesheet with PIN "3030"
@@ -765,6 +808,8 @@ Feature: Create tickets
     And I should see the split tips amount for employee "Kelley" is zero
     When I click on the "OK" button
     Then I should see the selected "SERVICE" tab on the Home page
+
+    When I clock out the timesheet with PIN "3030"
 
   Scenario: Cannot pay more than the Gift card Balance
     Given I am on the HOME page
@@ -817,7 +862,8 @@ Feature: Create tickets
 
     When I reopen to void ticket with payment amount "$35.71"
     Then I should see the selected "SERVICE" tab on the Home page
-    # And I should not see the employee "Aubrey" in the ticket list
+
+    When I clock out the timesheet with PIN "4040"
 
   Scenario: Add the Discount ticket while paying
     Given I am on the HOME page
@@ -839,6 +885,8 @@ Feature: Create tickets
 
     When I pay the exact amount by "Cash"
     Then I should see the selected "SERVICE" tab on the Home page
+
+    When I clock out the timesheet with PIN "6512"
 
   Scenario: No cash discount is charged when selling GC
     Given I am on the HOME page
@@ -868,6 +916,8 @@ Feature: Create tickets
     # Then I should see the payment history "VISA (1234)$106.18" visible
     When I click on the "Close Ticket" button
     Then I should see the selected "SERVICE" tab on the Home page
+
+    When I clock out the timesheet with PIN "8903"
 
   Scenario: Update GC balance when making multiple payments using 2 GCs
     Given I am on the HOME page
@@ -930,6 +980,8 @@ Feature: Create tickets
     Then I should see a popup dialog with title 'Confirm Delete'
     When I click on the "confirm" button in the popup dialog
 
+    When I clock out the timesheet with PIN "8526"
+
   Scenario: Queue - show Total, Last Service, Clock In Time
     Given I am on the HOME page
     When I clock in the timesheet with PIN "7779"
@@ -960,6 +1012,8 @@ Feature: Create tickets
     When I reopen to void ticket with payment amount "$20.11"
     Then I should see the selected "SERVICE" tab on the Home page
 
+    When I clock out the timesheet with PIN "7779"
+
   Scenario: In Service - show Service Count, Price Service Ticket
     Given I am on the HOME page
     When I clock in the timesheet with PIN "5839"
@@ -986,6 +1040,8 @@ Feature: Create tickets
     And I pay the exact amount by "Cash"
     Then I should see the selected "SERVICE" tab on the Home page
 
+    When I clock out the timesheet with PIN "5839"
+
   Scenario: Can close ticket $0.00
     Given I am on the HOME page
     When I clock in the timesheet with PIN "3732"
@@ -1005,20 +1061,22 @@ Feature: Create tickets
 
   Scenario: Services are displayed in the correct order
     Given I am on the HOME page
-    When I clock in the timesheet with PIN "4831"
+    When I clock in the timesheet with PIN "2486"
     And I wait for the page fully loaded
-    Then I should see the employee "Calantha" in the employee list
-    When I select the "Calantha" employee
+    Then I should see the employee "Service Order" in the employee list
+    When I select the "Service Order" employee
     Then I should see the "Ticket View" screen
     And I should see the services displayed correctly in ticket view
     When I void the current open ticket with reason "System Test"
 
+    When I clock out the timesheet with PIN "2486"
+
   Scenario: Discount items are in the correct order
     Given I am on the HOME page
-    When I clock in the timesheet with PIN "4831"
+    When I clock in the timesheet with PIN "1173"
     And I wait for the page fully loaded
-    Then I should see the employee "Calantha" in the employee list
-    When I select the "Calantha" employee
+    Then I should see the employee "Discount Order" in the employee list
+    When I select the "Discount Order" employee
     Then I should see the "Ticket View" screen
 
     When I add the "Manicure" service to my cart
@@ -1028,4 +1086,50 @@ Feature: Create tickets
 
     When I click on the "Cancel" button
     And I void the current open ticket with reason "System Test"
+    And I wait for the page fully loaded
+    And I clock out the timesheet with PIN "1173"
 
+  Scenario: Add multiple discounts
+    Given I am on the HOME page
+    When I clock in the timesheet with PIN "1000"
+    Then I should see the employee "Donna" in the employee list
+    When I select the "Donna" employee
+    Then I should see the "Ticket View" screen
+    And I should see the "Manicure" service
+
+    When I wait for the page fully loaded
+    When I add the "Manicure" service to my cart
+    Then I should see my cart showing 1 item added
+
+    When I select the service "Manicure" in my cart
+    And I select the "DISCOUNT ITEM" on the menu
+    Then I should see the "Original Price (Owner)" option is active
+
+    When I select the discount "Open Discount"
+    Then I should see the "Amount" discount type is active
+    When I enter the amount "3"
+    And I click on the "OK" button
+    Then I should see the "Open Discount (Original Price)" discount in my cart
+    And I should see discount "($3.00)" in my cart
+
+    When I select the service "Manicure" in my cart
+    And I select the "DISCOUNT ITEM" on the menu
+    And I click on the "Add Discount" text inside the content section of the opening dialog
+    Then I should see the "Original Price (Owner)" option is active
+
+    When I select the discount absorb type "Discounted Price (Technician)"
+    Then I should see the "Discounted Price (Technician)" option is active
+
+    When I select the discount "Open Discount"
+    And I select the "Percent" discount type
+    Then I should see the "Percent" discount type is active
+
+    When I enter the amount "10"
+    And I click on the "OK" button
+    Then I should see the "Open Discount 10% (Discounted Price)" discount in my cart
+    And I should see discount "($0.30)" in my cart
+
+    When I pay the exact amount by "Cash"
+    Then I should see the selected "SERVICE" tab on the Home page
+
+    When I clock out the timesheet with PIN "1000"

--- a/e2e/galaxy-pink-web/src/features/departments.feature
+++ b/e2e/galaxy-pink-web/src/features/departments.feature
@@ -8,7 +8,8 @@ Feature: Departments management
     And I select the "Departments" label in the expanded list
     Then I should be redirected to DEPARTMENT page
     And I should see the "Departments" screen
-
+    
+  @skip
   Scenario: Create a new department
     Given I am on the HOME page
     When I click on the header menu

--- a/e2e/galaxy-pink-web/src/features/discounts.feature
+++ b/e2e/galaxy-pink-web/src/features/discounts.feature
@@ -9,7 +9,7 @@ Feature: Discounts management
     Then I should be redirected to DISCOUNT page
     And I should see the "Discounts" screen
 
-  @skip @fix
+  @skip
   Scenario: Create a new Discount
    Given I am on the HOME page
     When I click on the header menu

--- a/e2e/galaxy-pink-web/src/features/payroll.feature
+++ b/e2e/galaxy-pink-web/src/features/payroll.feature
@@ -146,7 +146,8 @@ Feature: Payroll
 
     When I reopen to void ticket with payment amount "$218.87"
     Then I should see the selected "SERVICE" tab on the Home page
-    # And I should not see the employee "Sydney" in the ticket list
+
+    When I clock out the timesheet with PIN "6789"
 
   Scenario: Commission payroll details in the Owner View are calculated correctly
     Given I am on the HOME page
@@ -230,7 +231,8 @@ Feature: Payroll
 
     When I reopen to void ticket with payment amount "$229.17"
     Then I should see the selected "SERVICE" tab on the Home page
-    # And I should not see the employee "Venus" in the ticket list
+
+    When I clock out the timesheet with PIN "9969"
 
   Scenario: Hourly payroll details in the Employee View are calculated correctly
     Given I am on the HOME page

--- a/e2e/galaxy-pink-web/src/features/positions.feature
+++ b/e2e/galaxy-pink-web/src/features/positions.feature
@@ -8,7 +8,8 @@ Feature: Positions management
     And I select the "Positions" label in the expanded list
     Then I should be redirected to POSITIONS page
     And I should see the "Positions" screen
-  @skip @fix
+    
+  @skip
   Scenario: Add and then delete a Position
     Given I am on the HOME page
     When I click on the header menu

--- a/e2e/galaxy-pink-web/src/features/quick-payroll.feature
+++ b/e2e/galaxy-pink-web/src/features/quick-payroll.feature
@@ -101,7 +101,8 @@ Feature: Quick payroll
 
     When I reopen to void ticket with payment amount "$249.77"
     Then I should see the selected "SERVICE" tab on the Home page
-    # And I should not see the employee "Serena" in the ticket list
+
+    When I clock out the timesheet with PIN "2771"
 
   Scenario: Display Hourly payroll details correctly in the payroll summary
     Given I am on the HOME page
@@ -173,4 +174,3 @@ Feature: Quick payroll
 
     When I reopen to void ticket with payment amount "$250.80"
     Then I should see the selected "SERVICE" tab on the Home page
-    # And I should not see the employee "Jen" in the ticket list

--- a/e2e/galaxy-pink-web/src/features/tax.feature
+++ b/e2e/galaxy-pink-web/src/features/tax.feature
@@ -9,7 +9,8 @@ Feature: Tax management
     And I select the "Tax" label in the expanded list
     Then I should be redirected to TAX page
     And I should see the "Tax" screen
-  @skip @fix
+    
+  @skip
   Scenario: Add and then delete a Tax
     Given I am on the TAX page
     # When I wait for the page fully loaded

--- a/e2e/galaxy-pink-web/src/features/ticket-adjustment.feature
+++ b/e2e/galaxy-pink-web/src/features/ticket-adjustment.feature
@@ -56,6 +56,9 @@ Feature: Ticket adjustment
     And I wait for the page fully loaded
     Then I should see the text "Please select a ticket." in the ticket adjustment screen
 
+    When I back to HOME page
+    And I clock out the timesheet with PIN "8573"
+
   Scenario: View service details
     Given I am on the HOME page
     When I clock in the timesheet with PIN "9610"
@@ -115,6 +118,9 @@ Feature: Ticket adjustment
     And I should see the detail "Item Supply Fee($3.00)"
     And I should see the detail "Package Amount$29.00"
     And I should see the detail "Commission$15.00"
+
+    When I back to HOME page
+    And I clock out the timesheet with PIN "9610"
 
   Scenario: Create a ticket for today, add tip, apply discount item and apply discount ticket
     Given I am on the HOME page
@@ -292,6 +298,9 @@ Feature: Ticket adjustment
     And I wait for the page fully loaded
     Then I should see the text "Please select a ticket." in the ticket adjustment screen
 
+    When I back to HOME page
+    And I clock out the timesheet with PIN "3412"
+
   Scenario: Change tech and split tip
     Given I am on the HOME page
     When I clock in the timesheet with PIN "8414"
@@ -359,6 +368,9 @@ Feature: Ticket adjustment
     When I click on the "SAVE" button in the popup dialog
     And I wait for the page fully loaded
     Then I should see the text "Please select a ticket." in the ticket adjustment screen
+
+    When I back to HOME page
+    And I clock out the timesheet with PIN "8414"
 
   Scenario: Update GC balance after voiding a sell Gift Card
     Given I am on the HOME page
@@ -429,6 +441,9 @@ Feature: Ticket adjustment
     Then I should see the first type "ActivateNew" in the gift card detail list
     And I should see the first amount "$50.00" in the gift card detail list
 
+    When I back to HOME page
+    And I clock out the timesheet with PIN "5720"
+
   Scenario: Remove Tax and make new payment
     Given I am on the HOME page
     When I clock in the timesheet with PIN "8754"
@@ -483,6 +498,9 @@ Feature: Ticket adjustment
     When I click on the "SAVE" button in the popup dialog
     And I wait for the page fully loaded
     Then I should see the text "Please select a ticket." in the ticket adjustment screen
+
+    When I back to HOME page
+    And I clock out the timesheet with PIN "8754"
 
   Scenario: Add Tax and make new payment
     Given I am on the HOME page
@@ -539,6 +557,9 @@ Feature: Ticket adjustment
     And I wait for the page fully loaded
     Then I should see the text "Please select a ticket." in the ticket adjustment screen
 
+    When I back to HOME page
+    And I clock out the timesheet with PIN "1648"
+
   Scenario: Update loyalty when adding a customer to the ticket
     Given I am on the HOME page
     When I clock in the timesheet with PIN "4170"
@@ -588,3 +609,6 @@ Feature: Ticket adjustment
     Then I should see the first date is today in the loyalty detail list
     And I should see the first type "Issuance" in the loyalty detail list
     And I should see the first amount "51" in the gift card detail list
+
+    When I back to HOME page
+    And I clock out the timesheet with PIN "4170"

--- a/e2e/galaxy-pink-web/src/features/ticket-payments.feature
+++ b/e2e/galaxy-pink-web/src/features/ticket-payments.feature
@@ -88,7 +88,8 @@ Feature: Ticket Payments
 
     When I reopen to void ticket with payment amount "$232.26"
     Then I should see the selected "SERVICE" tab on the Home page
-    # And I should not see the employee "Hilary" in the ticket list
+
+    When I clock out the timesheet with PIN "1250"
 
   Scenario: The Services/Products tab displays data correctly
     Given I am on the HOME page
@@ -167,9 +168,6 @@ Feature: Ticket Payments
     And I should see the "Ticket Disc $" has value "($6.67)" in the ticket payment
     And I should see the "Ticket Disc %" has value "$0.00" in the ticket payment
 
-    # And I should see the "Closed By" has value "Hilary" in the ticket payment
-    # Then I should see the Total Sale, Payment, Surcharge, Card Fee, Tip, Tax, Closed By as "$218.70 $232.26 $3.56 $10.00 $0.00 Hilary" in the tickets details
-
     When I back to HOME page
     And I select the "CLOSED TICKET" tab
     And I wait for the page fully loaded
@@ -180,8 +178,8 @@ Feature: Ticket Payments
 
     When I reopen to void ticket with payment amount "$71.83"
     Then I should see the selected "SERVICE" tab on the Home page
-    # And I should not see the employee "Valerie" in the ticket list
 
+    When I clock out the timesheet with PIN "6118"
 
 
 

--- a/e2e/galaxy-pink-web/src/features/turn-details.feature
+++ b/e2e/galaxy-pink-web/src/features/turn-details.feature
@@ -121,7 +121,8 @@ Feature: Turn details
 
     When I reopen to void ticket with payment amount "$23.58"
     Then I should see the selected "SERVICE" tab on the Home page
-    # And I should not see the employee "Zoey" in the ticket list
+
+    When I clock out the timesheet with PIN "3818"
 
   Scenario: Manually adding decrease a turn reorders the employee queue
     Given I am on the HOME page
@@ -226,6 +227,8 @@ Feature: Turn details
     And I waiting 1s
     Then I should see Employee "Late Turn" with "C = 0.0" in the employee list
 
+    When I clock out the timesheet with PIN "0210"
+
  Scenario: Adjust turn - Add Go Again, Remove Go Again
     Given I am on the HOME page
     When I clock in the timesheet with PIN "0466"
@@ -287,6 +290,8 @@ Feature: Turn details
     And I wait for the page fully loaded
     Then I should see the toast message "deleted successfully" visible
 
+    When I clock out the timesheet with PIN "0466"
+
  Scenario: Adjust turn - Move, Remove Move
     Given I am on the HOME page
     When I clock in the timesheet with PIN "5781"
@@ -310,6 +315,8 @@ Feature: Turn details
     When I click on the "Remove Move" in turn adjustment
     And I wait for the page fully loaded
     Then I should see the employee "Move" is not at position 1
+
+    When I clock out the timesheet with PIN "5781"
 
   Scenario: View turn details correctly on the receipt
     Given I am on the HOME page
@@ -357,3 +364,5 @@ Feature: Turn details
 
     When I reopen to void ticket with payment amount "$255.70"
     Then I should see the selected "SERVICE" tab on the Home page
+
+    When I clock out the timesheet with PIN "3328"

--- a/e2e/pos-web/src/features/create-tickets.feature
+++ b/e2e/pos-web/src/features/create-tickets.feature
@@ -1233,18 +1233,18 @@ Feature: Create tickets
 
   Scenario: Services are displayed in the correct order
     Given I am on the HOME page
-    When I clock in the timesheet with PIN "4831"
-    Then I should see the employee "Calantha" in the employee list
-    When I select the "Calantha" employee
+    When I clock in the timesheet with PIN "2486"
+    Then I should see the employee "Service Order" in the employee list
+    When I select the "Service Order" employee
     Then I should see the "Ticket View" screen
     And I should see the services displayed correctly in ticket view
     When I void the current open ticket with reason "System Test"
 
   Scenario: Discount items are in the correct order
     Given I am on the HOME page
-    When I clock in the timesheet with PIN "4831"
-    Then I should see the employee "Calantha" in the employee list
-    When I select the "Calantha" employee
+    When I clock in the timesheet with PIN "1173"
+    Then I should see the employee "Discount Order" in the employee list
+    When I select the "Discount Order" employee
     Then I should see the "Ticket View" screen
 
     When I add the "Manicure" service to my cart
@@ -1253,3 +1253,48 @@ Feature: Create tickets
     Then I should see the discount sorted correctly
     When I close the popup dialog
     And I void the current open ticket with reason "System Test"
+
+    When I clock out the timesheet with PIN "1173"
+    
+  Scenario: Add multiple discounts
+    Given I am on the HOME page
+    When I clock in the timesheet with PIN "1000"
+    Then I should see the employee "Donna" in the employee list
+    When I select the "Donna" employee
+    Then I should see the "Ticket View" screen
+    And I should see the "Manicure" service
+
+    When I wait for the page fully loaded
+    When I add the "Manicure" service to my cart
+    Then I should see my cart showing 1 item added
+
+    When I click on the item "DISCOUNT ITEM" button
+    Then I should see a popup dialog with title "DISCOUNT MULTIPLE"
+    When I select the "Manicure" service in the dialog
+    Then I should see the "Owner Absorbs" option is checked
+
+    When I select the discount "Open Discount"
+    And I select the type "Amount" option
+    Then I should see the discount type "Amount" visible
+    When I enter the discount amount "3"
+    And I click on the "Add Value" button in the popup dialog
+    And I click on the "Apply" button in the popup dialog
+    Then I should see the discount item "Open Discount (Owner Absorbs) ($3.00)" in my cart
+
+    When I click on the item "DISCOUNT ITEM" button
+    And I select the "Manicure" service in the dialog
+    And I select the discount "Open Discount"
+    And I select the "Percent" discount type
+    And I enter the discount percent "10"
+    And I click on the "Add Value" button in the popup dialog
+    And I click on the "Apply" button in the popup dialog
+    Then I should see the discount item "Open Discount (Owner Absorbs) ($0.30)" in my cart
+
+    When I click on the "PAY" button
+    And I click on the element with id "payment"
+    Then I should see a popup dialog with title "Close Ticket"
+    And I should see a popup dialog with content "CHANGE$0.00OK"
+    When I click on the "OK" button in the popup dialog
+    Then I should be redirected to HOME page
+
+    When I clock out the timesheet with PIN "1000"

--- a/e2e/pos-web/src/features/steps.ts
+++ b/e2e/pos-web/src/features/steps.ts
@@ -4439,3 +4439,14 @@ Then('I should see the discount sorted correctly', async ({ page }) => {
 When('I close the popup dialog', async ({ page }) => {
 	await page.locator('button[title="Close"]').click();
 });
+
+When('I select the {string} discount type', async ({ page }, type: string) => {
+	const typeDiscount = page.locator('#mui-component-select-typeDiscount');
+
+	await expect(typeDiscount).toBeVisible();
+	await typeDiscount.click();
+
+	const discountElement = page.locator('ul.MuiMenu-list li').getByText(type);
+	await expect(discountElement).toHaveText(type);
+	await discountElement.click();
+});

--- a/e2e/pos-web/src/steps/ticket-view.page.ts
+++ b/e2e/pos-web/src/steps/ticket-view.page.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { Fixture, When } from 'playwright-bdd/decorators';
+import { Fixture, Then, When } from 'playwright-bdd/decorators';
 
 import { constants } from '#const';
 import { PageId } from '#types';
@@ -102,5 +102,30 @@ class TicketViewPage extends xPage {
 	@When('I void the current open ticket with reason {string}')
 	public async voidTicketWithProvidedReason(reason: string) {
 		return this.voidTicket(reason);
+	}
+
+	@Then('I should see the discount item {string} in my cart')
+	public async seeDiscountItem(fullText: string) {
+		const match = fullText.match(/^(.+?)\s*\(([^)]+)\)$/);
+
+		const discountItem = this.page.locator('.xTicketItems__discount');
+
+		if (match?.[1] && match?.[2]) {
+			await expect(
+				discountItem
+					.filter({
+						has: this.page.locator('.xTicketItems__discount--title', {
+							hasText: match[1].trim(),
+						}),
+					})
+					.filter({
+						has: this.page.locator('.xTicketItems__discount--price', {
+							hasText: `(${match[2]})`,
+						}),
+					}),
+			).toBeVisible();
+		} else {
+			await expect(discountItem.filter({ hasText: fullText })).toBeVisible();
+		}
 	}
 }


### PR DESCRIPTION
## Summary by Sourcery

Add end-to-end coverage for applying multiple discounts and improve test stability and timesheet cleanup across ticket, payments, and reporting flows.

Tests:
- Add new e2e scenarios on Galaxy Pink Web and POS Web to verify applying multiple discounts to services and correct discount item display.
- Enhance ticket, closed-ticket, ticket-adjustment, turn-details, ticket-payments, close-out, payroll, quick-payroll, and queue order scenarios with explicit wait-for-load and timesheet clock-out steps to ensure clean test state.
- Update existing tests to use new employee fixtures and PINs for service/discount order validations, and adjust expectations accordingly.
- Introduce reusable step definitions for verifying discount items in the cart and selecting discount types in POS Web tests.
- Mark certain Galaxy Pink Web management scenarios for departments, positions, tax, and discounts as skipped to exclude unstable or out-of-scope flows from the suite.